### PR TITLE
Check for null date object on keyboard picker change handler

### DIFF
--- a/lib/src/_shared/hooks/useKeyboardPickerState.ts
+++ b/lib/src/_shared/hooks/useKeyboardPickerState.ts
@@ -41,7 +41,7 @@ export function useKeyboardPickerState(props: BaseKeyboardPickerProps, options: 
   }, [format, props, props.value, utils]);
 
   function handleChange(date: MaterialUiPickersDate) {
-    const dateString = utils.format(date, format);
+    const dateString = date === null ? null : utils.format(date, format);
 
     props.onChange(date, dateString);
   }


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

This PR closes #1035

## Description

Check to see if the date object is null when handling a change on the keyboard picker. Otherwise an error is thrown when pressing the clear button. 
