### PR TITLE
Use wildcard import rather than default import

### DIFF
--- a/lib/src/wrappers/Wrapper.tsx
+++ b/lib/src/wrappers/Wrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ModalWrapper, { ModalWrapperProps } from './ModalWrapper';
 import InlineWrapper, { InlineWrapperProps } from './InlineWrapper';
 import { Omit } from '@material-ui/core';


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

This PR closes # <!-- Please refer issue number here, if exists -->

## Description

Fixes https://github.com/mui-org/material-ui-pickers/issues/1037