### PR TITLE
Fix openTo of DateTimePicker

### DIFF
--- a/lib/src/DateTimePicker/DateTimePickerRoot.tsx
+++ b/lib/src/DateTimePicker/DateTimePickerRoot.tsx
@@ -63,9 +63,10 @@ const DateTimePickerRoot: React.FC<DateTimePickerProps> = ({
   onChange,
   onMonthChange,
   onYearChange,
+  openTo = 'date',
 }) => {
   const utils = useUtils();
-  const [openView, setOpenView] = React.useState<DateTimePickerViewType>('date');
+  const [openView, setOpenView] = React.useState<DateTimePickerViewType>(openTo);
   const { meridiemMode, handleMeridiemChange } = useMeridiemMode(date, ampm, onChange);
 
   const handleChangeAndOpenNext = React.useCallback(

--- a/lib/src/__tests__/e2e/DateTimePickerRoot.test.tsx
+++ b/lib/src/__tests__/e2e/DateTimePickerRoot.test.tsx
@@ -70,4 +70,8 @@ describe('e2e - DateTimePicker', () => {
 
     expect(onChangeMock).toHaveBeenCalledWith(utilsToUse.date('2018-01-01T12:00:00.000Z'), false);
   });
+
+  it('Should open to hours view', () => {
+    expect(component.find('.MuiPickersClock-container')).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->


## Description
When you reworked DateTimePicker from class to hooks you forgot to support openTo.
This fixes it (defaults to "date") and adds a test for it.