### PR TITLE
Update calculation of Calendar slide direction

### DIFF
--- a/lib/src/DatePicker/components/Calendar.tsx
+++ b/lib/src/DatePicker/components/Calendar.tsx
@@ -70,7 +70,8 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
 
     if (!utils.isEqual(nextDate, state.lastDate)) {
       const nextMonth = utils.getMonth(nextDate);
-      const lastMonth = utils.getMonth(state.lastDate || nextDate);
+      const lastDate = state.lastDate || nextDate;
+      const lastMonth = utils.getMonth(lastDate);
 
       return {
         lastDate: nextDate,
@@ -78,7 +79,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
         // prettier-ignore
         slideDirection: nextMonth === lastMonth
           ? state.slideDirection
-          : nextMonth > lastMonth
+          : utils.isAfterDay(nextDate, lastDate)
             ? 'left'
             : 'right'
       };


### PR DESCRIPTION
## Description
Calculate Calendar slide direction with day precision rather than month.
If we update calendar date through the props it slides in a wrong direction.
![calendar-wrong-slide-direction](https://user-images.githubusercontent.com/1019401/57923305-9a4cab00-78aa-11e9-9006-5d7c08566b77.gif)
