### PR TITLE
Calculate calendar slide direction with day precision.

### DIFF
--- a/lib/src/DatePicker/components/Calendar.tsx
+++ b/lib/src/DatePicker/components/Calendar.tsx
@@ -90,7 +90,8 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
 
     if (!utils.isEqual(nextDate, state.lastDate)) {
       const nextMonth = utils.getMonth(nextDate);
-      const lastMonth = utils.getMonth(state.lastDate || nextDate);
+      const lastDate = state.lastDate || nextDate;
+      const lastMonth = utils.getMonth(lastDate);
 
       return {
         lastDate: nextDate,
@@ -98,7 +99,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
         // prettier-ignore
         slideDirection: nextMonth === lastMonth
           ? state.slideDirection
-          : nextMonth > lastMonth
+          : utils.isAfterDay(nextDate, lastDate)
             ? 'left'
             : 'right'
       };


### PR DESCRIPTION
## Description
Calculate Calendar slide direction with day precision rather than month.
If we update calendar date through the props it slides in a wrong direction.
![calendar-wrong-slide-direction](https://user-images.githubusercontent.com/1019401/58014097-ba75a780-7b00-11e9-9114-0f06b7e15d5f.gif)
