### PR TITLE
Properly pass refuse prop

### DIFF
--- a/lib/src/_shared/KeyboardDateInput.tsx
+++ b/lib/src/_shared/KeyboardDateInput.tsx
@@ -44,7 +44,6 @@ export interface KeyboardDateInputProps
   KeyboardButtonProps?: Partial<IconButtonProps>;
 }
 
-const refuse = /[^\dap]+/gi;
 const KeyboardDateInput: React.FunctionComponent<KeyboardDateInputProps> = ({
   inputValue,
   inputVariant,
@@ -56,6 +55,7 @@ const KeyboardDateInput: React.FunctionComponent<KeyboardDateInputProps> = ({
   InputProps,
   mask,
   maskChar = '_',
+  refuse = /[^\dap]+/gi,
   format,
   disabled,
   ...other


### PR DESCRIPTION
refuse prop was never actually used, it was always /[^\dap]+/gi