### PR TITLE
[DatePicker] add strictCompareDates prop

### DIFF
--- a/lib/src/DatePicker/DatePicker.tsx
+++ b/lib/src/DatePicker/DatePicker.tsx
@@ -26,7 +26,7 @@ export interface BaseDatePickerProps extends OutterCalendarProps {
    * Compare date isBefore or isAfter without utils endOfDay or startOfDay
    * @default false
    */
-  validateStrict?: boolean;
+  strictCompareDates?: boolean;
 
   /**
    * Disable past dates

--- a/lib/src/DatePicker/DatePicker.tsx
+++ b/lib/src/DatePicker/DatePicker.tsx
@@ -21,6 +21,13 @@ export interface BaseDatePickerProps extends OutterCalendarProps {
    * @default Date(2100-01-01)
    */
   maxDate?: ParsableDate;
+
+  /**
+   * Compare date isBefore or isAfter without utils endOfDay or startOfDay
+   * @default false
+   */
+  validateStrict?: boolean;
+
   /**
    * Disable past dates
    * @default false

--- a/lib/src/Picker/WrappedPurePicker.tsx
+++ b/lib/src/Picker/WrappedPurePicker.tsx
@@ -37,6 +37,7 @@ export function makePurePicker<T extends any>({
       onOpen,
       onClose,
       minDateMessage,
+      validateStrict,
       minutesStep,
       onAccept,
       onChange,
@@ -84,6 +85,7 @@ export function makePurePicker<T extends any>({
           leftArrowButtonProps={leftArrowButtonProps}
           maxDate={maxDate}
           minDate={minDate}
+          validateStrict={validateStrict}
           onMonthChange={onMonthChange}
           onYearChange={onYearChange}
           renderDay={renderDay}

--- a/lib/src/Picker/WrappedPurePicker.tsx
+++ b/lib/src/Picker/WrappedPurePicker.tsx
@@ -37,7 +37,7 @@ export function makePurePicker<T extends any>({
       onOpen,
       onClose,
       minDateMessage,
-      validateStrict,
+      strictCompareDates,
       minutesStep,
       onAccept,
       onChange,
@@ -85,7 +85,7 @@ export function makePurePicker<T extends any>({
           leftArrowButtonProps={leftArrowButtonProps}
           maxDate={maxDate}
           minDate={minDate}
-          validateStrict={validateStrict}
+          strictCompareDates={strictCompareDates}
           onMonthChange={onMonthChange}
           onYearChange={onYearChange}
           renderDay={renderDay}

--- a/lib/src/_helpers/text-field-helper.ts
+++ b/lib/src/_helpers/text-field-helper.ts
@@ -86,25 +86,34 @@ export const validate = (
   }
 
   if (
-    (maxDate &&
-      utils.isAfter(
-        parsedValue,
-        getComparisonMaxDate(utils, !!strictCompareDates, utils.date(maxDate))
-      )) ||
-    (disableFuture &&
-      utils.isAfter(parsedValue, getComparisonMaxDate(utils, !!strictCompareDates, utils.date())))
+    maxDate &&
+    utils.isAfter(
+      parsedValue,
+      getComparisonMaxDate(utils, !!strictCompareDates, utils.date(maxDate))
+    )
   ) {
     return maxDateMessage;
   }
 
   if (
-    (minDate &&
-      utils.isBefore(
-        parsedValue,
-        getComparisonMinDate(utils, !!strictCompareDates, utils.date(minDate))
-      )) ||
-    (disablePast &&
-      utils.isBefore(parsedValue, getComparisonMinDate(utils, !!strictCompareDates, utils.date())))
+    disableFuture &&
+    utils.isAfter(parsedValue, getComparisonMaxDate(utils, !!strictCompareDates, utils.date()))
+  ) {
+    return maxDateMessage;
+  }
+
+  if (
+    minDate &&
+    utils.isBefore(
+      parsedValue,
+      getComparisonMinDate(utils, !!strictCompareDates, utils.date(minDate))
+    )
+  ) {
+    return minDateMessage;
+  }
+  if (
+    disablePast &&
+    utils.isBefore(parsedValue, getComparisonMinDate(utils, !!strictCompareDates, utils.date()))
   ) {
     return minDateMessage;
   }

--- a/lib/src/_helpers/text-field-helper.ts
+++ b/lib/src/_helpers/text-field-helper.ts
@@ -44,6 +44,22 @@ export interface DateValidationProps extends BaseValidationProps {
   maxDateMessage?: React.ReactNode;
 }
 
+const getComparisonMaxDate = (utils: IUtils<any>, validateStrict: boolean, date: Date) => {
+  if (validateStrict) {
+    return date;
+  }
+
+  return utils.endOfDay(date);
+};
+
+const getComparisonMinDate = (utils: IUtils<any>, validateStrict: boolean, date: Date) => {
+  if (validateStrict) {
+    return date;
+  }
+
+  return utils.startOfDay(date);
+};
+
 export const validate = (
   value: ParsableDate,
   utils: IUtils<any>,
@@ -55,6 +71,7 @@ export const validate = (
     maxDateMessage,
     minDateMessage,
     invalidDateMessage,
+    validateStrict,
   }: Omit<DatePickerProps, 'views' | 'openTo'> // DateTimePicker doesn't support
 ): React.ReactNode => {
   const parsedValue = utils.date(value);
@@ -69,15 +86,25 @@ export const validate = (
   }
 
   if (
-    (maxDate && utils.isAfter(parsedValue, utils.endOfDay(utils.date(maxDate)))) ||
-    (disableFuture && utils.isAfter(parsedValue, utils.endOfDay(utils.date())))
+    (maxDate &&
+      utils.isAfter(
+        parsedValue,
+        getComparisonMaxDate(utils, !!validateStrict, utils.date(maxDate))
+      )) ||
+    (disableFuture &&
+      utils.isAfter(parsedValue, getComparisonMaxDate(utils, !!validateStrict, utils.date())))
   ) {
     return maxDateMessage;
   }
 
   if (
-    (minDate && utils.isBefore(parsedValue, utils.startOfDay(utils.date(minDate)))) ||
-    (disablePast && utils.isBefore(parsedValue, utils.startOfDay(utils.date())))
+    (minDate &&
+      utils.isBefore(
+        parsedValue,
+        getComparisonMinDate(utils, !!validateStrict, utils.date(minDate))
+      )) ||
+    (disablePast &&
+      utils.isBefore(parsedValue, getComparisonMinDate(utils, !!validateStrict, utils.date())))
   ) {
     return minDateMessage;
   }

--- a/lib/src/_helpers/text-field-helper.ts
+++ b/lib/src/_helpers/text-field-helper.ts
@@ -44,16 +44,16 @@ export interface DateValidationProps extends BaseValidationProps {
   maxDateMessage?: React.ReactNode;
 }
 
-const getComparisonMaxDate = (utils: IUtils<any>, validateStrict: boolean, date: Date) => {
-  if (validateStrict) {
+const getComparisonMaxDate = (utils: IUtils<any>, strictCompareDates: boolean, date: Date) => {
+  if (strictCompareDates) {
     return date;
   }
 
   return utils.endOfDay(date);
 };
 
-const getComparisonMinDate = (utils: IUtils<any>, validateStrict: boolean, date: Date) => {
-  if (validateStrict) {
+const getComparisonMinDate = (utils: IUtils<any>, strictCompareDates: boolean, date: Date) => {
+  if (strictCompareDates) {
     return date;
   }
 
@@ -71,7 +71,7 @@ export const validate = (
     maxDateMessage,
     minDateMessage,
     invalidDateMessage,
-    validateStrict,
+    strictCompareDates,
   }: Omit<DatePickerProps, 'views' | 'openTo'> // DateTimePicker doesn't support
 ): React.ReactNode => {
   const parsedValue = utils.date(value);
@@ -89,10 +89,10 @@ export const validate = (
     (maxDate &&
       utils.isAfter(
         parsedValue,
-        getComparisonMaxDate(utils, !!validateStrict, utils.date(maxDate))
+        getComparisonMaxDate(utils, !!strictCompareDates, utils.date(maxDate))
       )) ||
     (disableFuture &&
-      utils.isAfter(parsedValue, getComparisonMaxDate(utils, !!validateStrict, utils.date())))
+      utils.isAfter(parsedValue, getComparisonMaxDate(utils, !!strictCompareDates, utils.date())))
   ) {
     return maxDateMessage;
   }
@@ -101,10 +101,10 @@ export const validate = (
     (minDate &&
       utils.isBefore(
         parsedValue,
-        getComparisonMinDate(utils, !!validateStrict, utils.date(minDate))
+        getComparisonMinDate(utils, !!strictCompareDates, utils.date(minDate))
       )) ||
     (disablePast &&
-      utils.isBefore(parsedValue, getComparisonMinDate(utils, !!validateStrict, utils.date())))
+      utils.isBefore(parsedValue, getComparisonMinDate(utils, !!strictCompareDates, utils.date())))
   ) {
     return minDateMessage;
   }


### PR DESCRIPTION
Add strict camparison for minDate, maxDate, disablePast, disableFuture

This PR closes #953 

## Description
Add property to force strict comparison on minDate, maxDate, disablePast and disableFuture
Exemple: without validateStrict no maxDateMessage is shown
```
  return (
      <>
          <KeyboardDateTimePicker
              label="Wiil nopt show max date message"
              value={new Date('2019-05-28T23:00:00.000Z')}
              maxDate={new Date('2019-05-28T00:00:00.000Z')}
          />
          <KeyboardDateTimePicker
              label="Will show max date message"
              validateStrict
              value={new Date('2019-05-28T23:00:00.000Z')}
              maxDate={new Date('2019-05-28T00:00:00.000Z')}
          />
      </>
  );
```
