### PR TITLE
Fix Typescript override example

### DIFF
--- a/docs/pages/guides/css-overrides.mdx
+++ b/docs/pages/guides/css-overrides.mdx
@@ -37,9 +37,13 @@ For TypeScript users it's also required to extend default material-ui theme typi
 (This will also autocomplete classnames)
 
 ```typescript
-declare module '@material-ui/core/styles/overrides' {
-  import { MuiPickersOverrides } from '@material-ui/pickers/typings/overrides'
+import { Overrides } from "@material-ui/core/styles/overrides";
+import { MuiPickersOverrides } from 'material-ui-pickers/typings/overrides'
 
-  export interface Overrides extends MuiPickersOverrides { }
+type overridesNameToClassKey = { [P in keyof MuiPickersOverrides]: keyof
+MuiPickersOverrides[P] }
+
+declare module "@material-ui/core/styles/overrides" {
+    export interface ComponentNameToClassKey extends overridesNameToClassKey { }
 }
 ```


### PR DESCRIPTION
## Description

Material-ui style override definitions have changed, and the Typescript example provided is out of date.

Credit: https://stackoverflow.com/a/54890034 
Might be the same nick on Github, ping @arvymetal