### PR TITLE
Allow customized views inside the Picker

### DIFF
--- a/docs/pages/guides/CustomizeView.example.jsx
+++ b/docs/pages/guides/CustomizeView.example.jsx
@@ -1,0 +1,39 @@
+import React, { Fragment, useState } from 'react';
+import { DateTimePicker, TimePickerView, useUtils } from '@material-ui/pickers';
+import { Button } from '@material-ui/core';
+
+const CustomTimePickerView = props => {
+  const utils = useUtils();
+  return (
+    <div style={{ position: 'relative' }}>
+      <TimePickerView {...props} />
+      <Button
+        style={{ position: 'absolute', zIndex: 10, top: 0 }}
+        onClick={() => {
+          props.onHourChange(utils.mergeDateAndTime(props.date, new Date('2018-01-01 13:37')));
+        }}
+      >
+        {' '}
+        13:37{' '}
+      </Button>
+    </div>
+  );
+};
+
+function CustomizeViewExample() {
+  const [selectedDate, handleDateChange] = useState('2018-01-01T00:00:00.000Z');
+
+  return (
+    <Fragment>
+      <DateTimePicker
+        ampm={false}
+        viewComponents={{ hours: CustomTimePickerView }}
+        value={selectedDate}
+        onChange={handleDateChange}
+        label="Custom TimePickerView"
+      />
+    </Fragment>
+  );
+}
+
+export default CustomizeViewExample;

--- a/docs/pages/guides/customize-view.mdx
+++ b/docs/pages/guides/customize-view.mdx
@@ -1,0 +1,15 @@
+import Ad from '_shared/Ad'
+import Example from '_shared/Example'
+import PageMeta from '_shared/PageMeta'
+import * as CustomizeViewExample from './CustomizeView.example'
+
+<PageMeta title="Customize views" />
+
+## Customize views
+
+<Ad />
+
+The components for the main views (year selection, month selection, calendar for date selection, and time picker) can be
+replaced with custom components that accept the same props.
+
+<Example source={CustomizeViewExample} />

--- a/lib/src/Picker/Picker.tsx
+++ b/lib/src/Picker/Picker.tsx
@@ -49,6 +49,7 @@ export interface PickerViewProps extends BaseDatePickerProps, BaseTimePickerProp
 interface PickerProps extends PickerViewProps {
   date: MaterialUiPickersDate;
   onChange: (date: MaterialUiPickersDate, isFinish?: boolean) => void;
+  viewComponents?: Partial<typeof viewsMap>;
 }
 
 const useStyles = makeStyles(
@@ -89,6 +90,7 @@ export const Picker: React.FunctionComponent<PickerProps> = props => {
     onYearChange,
     leftArrowButtonProps,
     rightArrowButtonProps,
+    viewComponents,
     ToolbarComponent,
   } = props;
 
@@ -98,6 +100,9 @@ export const Picker: React.FunctionComponent<PickerProps> = props => {
 
   const minDate = React.useMemo(() => utils.date(unparsedMinDate)!, [unparsedMinDate, utils]);
   const maxDate = React.useMemo(() => utils.date(unparsedMaxDate)!, [unparsedMaxDate, utils]);
+
+  const effectiveComponents = { ...viewsMap, ...viewComponents };
+  const { year: YearComponent, month: MonthComponent, date: DateComponent } = effectiveComponents;
 
   return (
     <>
@@ -116,7 +121,7 @@ export const Picker: React.FunctionComponent<PickerProps> = props => {
 
       <div className={classes.pickerView}>
         {openView === 'year' && (
-          <YearSelection
+          <YearComponent
             date={date}
             onChange={handleChangeAndOpenNext('month')}
             minDate={minDate}
@@ -129,7 +134,7 @@ export const Picker: React.FunctionComponent<PickerProps> = props => {
         )}
 
         {openView === 'month' && (
-          <MonthSelection
+          <MonthComponent
             date={date}
             onChange={handleChangeAndOpenNext('date')}
             minDate={minDate}
@@ -141,7 +146,7 @@ export const Picker: React.FunctionComponent<PickerProps> = props => {
         )}
 
         {openView === 'date' && (
-          <Calendar
+          <DateComponent
             date={date}
             onChange={handleChangeAndOpenNext('hours')}
             onMonthChange={onMonthChange}
@@ -159,17 +164,16 @@ export const Picker: React.FunctionComponent<PickerProps> = props => {
           />
         )}
 
-        {(openView === 'hours' || openView === 'minutes' || openView === 'seconds') && (
-          <TimePickerView
-            date={date}
-            ampm={ampm}
-            type={openView}
-            minutesStep={minutesStep}
-            onHourChange={handleChangeAndOpenNext('minutes')}
-            onMinutesChange={handleChangeAndOpenNext('seconds')}
-            onSecondsChange={handleChangeAndOpenNext(null)}
-          />
-        )}
+        {(openView === 'hours' || openView === 'minutes' || openView === 'seconds') &&
+          React.createElement(effectiveComponents[openView], {
+            type: openView,
+            date,
+            ampm,
+            minutesStep,
+            onHourChange: handleChangeAndOpenNext('minutes'),
+            onMinutesChange: handleChangeAndOpenNext('seconds'),
+            onSecondsChange: handleChangeAndOpenNext(null),
+          })}
       </div>
     </>
   );

--- a/lib/src/Picker/WrappedKeyboardPicker.tsx
+++ b/lib/src/Picker/WrappedKeyboardPicker.tsx
@@ -51,6 +51,7 @@ export function makeKeyboardPicker<T extends any>({
       onYearChange,
       renderDay,
       views,
+      viewComponents,
       openTo,
       rightArrowIcon,
       rightArrowButtonProps,
@@ -81,6 +82,7 @@ export function makeKeyboardPicker<T extends any>({
           hideTabs={hideTabs}
           ampm={ampm}
           views={views}
+          viewComponents={viewComponents}
           openTo={openTo}
           allowKeyboardControl={allowKeyboardControl}
           minutesStep={minutesStep}

--- a/lib/src/Picker/WrappedPurePicker.tsx
+++ b/lib/src/Picker/WrappedPurePicker.tsx
@@ -44,6 +44,7 @@ export function makePurePicker<T extends any>({
       onYearChange,
       renderDay,
       views,
+      viewComponents,
       openTo,
       rightArrowIcon,
       rightArrowButtonProps,
@@ -74,6 +75,7 @@ export function makePurePicker<T extends any>({
           hideTabs={hideTabs}
           ampm={ampm}
           views={views}
+          viewComponents={viewComponents}
           openTo={openTo}
           allowKeyboardControl={allowKeyboardControl}
           minutesStep={minutesStep}


### PR DESCRIPTION
This allows users to swap out the `YearSelection` or `Calendar` (etc.) components hard-coded inside the `Picker` with a custom component that has a compatible interface. The code is still quite hacky and I wouldn't merge it like this (either switch all to `React.createElement()` or none). As a side effect, this PR fixes the confusing situation that the `viewsMap` values were never used.
(An alternative design would be to expose separate `YearComponent`, `CalendarComponent`, etc props.)

I'm sending this out early to ask if offering this level of customization to users is something you want to do with this library.

I read somewhere in `material-ui`'s or `material-ui-picker`'s documentation that the libraries are designed to be open for customization. In the past, a related `ViewContainerComponent` prop existed (see https://github.com/mui-org/material-ui-pickers/pull/531), which I had added, but the design was a bit weird (it exposed an implementation detail) and it was rightfully removed, as far as I can tell. I think this new solution is more generic/flexible (composition over inheritance/replacement), but at the same time more type-safe (see `typeof viewsMap`) and future-proof. Users of this API would have to accept that the contract is: "you supply a component that behaves like the built-in one", which is intentionally an indirect and volatile definition. As shown in the example code, users can write custom components that make only minimal assumptions about the built-in components they replace, so in practice they're unlikely to break.