### PR TITLE
[#1111] Properly rely on views order when switching views

### DIFF
--- a/lib/src/Picker/Picker.tsx
+++ b/lib/src/Picker/Picker.tsx
@@ -119,7 +119,7 @@ export const Picker: React.FunctionComponent<PickerProps> = props => {
         {openView === 'year' && (
           <YearSelection
             date={date}
-            onChange={handleChangeAndOpenNext('month')}
+            onChange={handleChangeAndOpenNext}
             minDate={minDate}
             maxDate={maxDate}
             disablePast={disablePast}
@@ -132,7 +132,7 @@ export const Picker: React.FunctionComponent<PickerProps> = props => {
         {openView === 'month' && (
           <MonthSelection
             date={date}
-            onChange={handleChangeAndOpenNext('date')}
+            onChange={handleChangeAndOpenNext}
             minDate={minDate}
             maxDate={maxDate}
             disablePast={disablePast}
@@ -144,7 +144,7 @@ export const Picker: React.FunctionComponent<PickerProps> = props => {
         {openView === 'date' && (
           <Calendar
             date={date}
-            onChange={handleChangeAndOpenNext('hours')}
+            onChange={handleChangeAndOpenNext}
             onMonthChange={onMonthChange}
             disablePast={disablePast}
             disableFuture={disableFuture}
@@ -167,9 +167,9 @@ export const Picker: React.FunctionComponent<PickerProps> = props => {
             ampm={ampm}
             type={openView}
             minutesStep={minutesStep}
-            onHourChange={handleChangeAndOpenNext('minutes')}
-            onMinutesChange={handleChangeAndOpenNext('seconds')}
-            onSecondsChange={handleChangeAndOpenNext(null)}
+            onHourChange={handleChangeAndOpenNext}
+            onMinutesChange={handleChangeAndOpenNext}
+            onSecondsChange={handleChangeAndOpenNext}
           />
         )}
       </div>

--- a/lib/src/_shared/hooks/useViews.tsx
+++ b/lib/src/_shared/hooks/useViews.tsx
@@ -11,31 +11,19 @@ export function useViews(
     openTo && views.includes(openTo) ? openTo : views[0]
   );
 
-  const getNextAvailableView = React.useCallback(
-    (nextView: PickerView) => {
-      if (views.includes(nextView)) {
-        return nextView;
-      }
-      return views[views.indexOf(openView!) + 1];
-    },
-    [openView, views]
-  );
-
   const handleChangeAndOpenNext = React.useCallback(
-    (nextView: PickerView | null) => {
-      return (date: MaterialUiPickersDate, isFinish?: boolean) => {
-        const nextViewToOpen = nextView && getNextAvailableView(nextView);
-        if (isFinish && nextViewToOpen) {
-          // do not close picker if needs to show next view
-          onChange(date, false);
-          setOpenView(nextViewToOpen);
-          return;
-        }
+    (date: MaterialUiPickersDate, isFinish?: boolean) => {
+      const nextViewToOpen = views[views.indexOf(openView!) + 1];
+      if (isFinish && nextViewToOpen) {
+        // do not close picker if needs to show next view
+        onChange(date, false);
+        setOpenView(nextViewToOpen);
+        return;
+      }
 
-        onChange(date, Boolean(isFinish));
-      };
+      onChange(date, Boolean(isFinish));
     },
-    [getNextAvailableView, onChange]
+    [onChange, openView, views]
   );
 
   return { handleChangeAndOpenNext, openView, setOpenView };


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

This PR closes #1111 <!-- Please refer issue number here, if exists -->

## Description
It was forgotten to remove while refactoring to v3. Properly rely on the order of `passed` views instead of hardocded values