### PR TITLE
Landscape orientation support 

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -18,6 +18,14 @@ class MyApp extends App<{ theme: ThemeType }> {
     return { theme, pageProps };
   }
 
+  componentDidMount() {
+    // Remove the server-side injected CSS.
+    const jssStyles = document.querySelector('#jss-server-side');
+    if (jssStyles && jssStyles.parentNode) {
+      jssStyles.parentNode.removeChild(jssStyles);
+    }
+  }
+
   render() {
     const { Component, pageProps, theme } = this.props;
 

--- a/docs/pages/demo/datepicker/StaticDatePicker.example.jsx
+++ b/docs/pages/demo/datepicker/StaticDatePicker.example.jsx
@@ -4,10 +4,25 @@ import { DatePicker } from '@material-ui/pickers';
 const StaticDatePicker = () => {
   const [date, changeDate] = useState(new Date());
 
+  // prettier-ignore
   return (
     <>
-      <DatePicker autoOk variant="static" openTo="year" value={date} onChange={changeDate} />
-      <DatePicker autoOk variant="static" openTo="date" value={date} onChange={changeDate} />
+      <DatePicker
+        autoOk
+        variant="static"
+        openTo="year"
+        value={date}
+        onChange={changeDate}
+      />
+
+      <DatePicker
+        autoOk
+        orientation="landscape"
+        variant="static"
+        openTo="date"
+        value={date}
+        onChange={changeDate}
+      />
     </>
   );
 };

--- a/docs/pages/demo/timepicker/StaticTimePicker.example.jsx
+++ b/docs/pages/demo/timepicker/StaticTimePicker.example.jsx
@@ -4,10 +4,25 @@ import { TimePicker } from '@material-ui/pickers';
 const StaticTimePicker = () => {
   const [date, changeDate] = useState(new Date());
 
+  // prettier-ignore
   return (
     <>
-      <TimePicker autoOk variant="static" openTo="hours" value={date} onChange={changeDate} />
-      <TimePicker autoOk variant="static" openTo="minutes" value={date} onChange={changeDate} />
+      <TimePicker
+        autoOk
+        variant="static"
+        openTo="hours"
+        value={date}
+        onChange={changeDate}
+      />
+
+      <TimePicker
+        autoOk
+        variant="static"
+        orientation="landscape"
+        openTo="minutes"
+        value={date}
+        onChange={changeDate}
+      />
     </>
   );
 };

--- a/docs/pages/localization/Hijri.example.jsx
+++ b/docs/pages/localization/Hijri.example.jsx
@@ -22,7 +22,6 @@ function HijriExample() {
         labelFunc={date => (date ? date.format('iYYYY/iMM/iDD') : '')}
         value={selectedDate}
         onChange={handleDateChange}
-        animateYearScrolling={false}
         minDate="1937-03-14"
         maxDate="2076-11-26"
       />

--- a/docs/pages/localization/Persian.example.jsx
+++ b/docs/pages/localization/Persian.example.jsx
@@ -24,7 +24,6 @@ function PersianExample() {
         labelFunc={date => (date ? date.format('jYYYY/jMM/jDD') : '')}
         value={selectedDate}
         onChange={handleDateChange}
-        animateYearScrolling={false}
       />
 
       <TimePicker

--- a/docs/pages/localization/calendar-systems.mdx
+++ b/docs/pages/localization/calendar-systems.mdx
@@ -1,8 +1,8 @@
 import Ad from '_shared/Ad';
-import Example from '_shared/Example'
-import PageMeta from '_shared/PageMeta'
-import * as PersianExample from './Persian.example.jsx'
-import * as HijriExample from './Hijri.example.jsx'
+import Example from '_shared/Example';
+import PageMeta from '_shared/PageMeta';
+import * as PersianExample from './Persian.example.jsx';
+import * as HijriExample from './Hijri.example.jsx';
 
 <PageMeta title="Additional Calendar Systems - @material-ui/pickers" />
 
@@ -15,7 +15,7 @@ material-ui documentation page before proceeding.
 
 Install the specified npm packages below for Jalaali or Hijri depending on which calendar system you will be using.
 
-#### Persian calendar system
+#### Jalaali calendar system
 
 Install `@date-io/jalaali` package from npm.
 
@@ -23,13 +23,13 @@ Install `@date-io/jalaali` package from npm.
 npm install @date-io/jalaali
 ```
 
-##### Example
+#### Example
 
 You can use the examples below. It is recommended that you change the font.
 
 <Example source={PersianExample} />
 
-<hr/>
+<hr />
 
 #### Hijri calendar system
 
@@ -41,21 +41,23 @@ npm install @date-io/hijri moment-hijri
 
 To use it with Arabic locale, make sure to import `moment/locale/ar-sa`
 
-```
+```javascript
 import 'moment/locale/ar-sa';
 ```
 
-By default, the `DatePicker` uses 1900-01-01 for minDate and 2100-01-01 for maxDate. `moment-hijri` only supports dates from 1356-01-01 H (1937-03-14) to 1499-12-29 H (2076-11-26) so you will need to set `minDate` and `maxDate` on your `DatePicker` component otherwise your component will not work properly.
+By default, the `DatePicker` uses `1900-01-01` for minDate and `2100-01-01` for maxDate.
+`moment-hijri` only supports dates from `1356-01-01` H (1937-03-14) to `1499-12-29` H (2076-11-26)
+so you will need to set `minDate` and `maxDate` on your `DatePicker` component otherwise your component will not work properly.
 
-```
+```jsx
 <DatePicker
-    ...
-    minDate="1937-03-14"
-    maxDate="2076-11-26"
+  // your props
+  minDate="1937-03-14"
+  maxDate="2076-11-26"
 />
 ```
 
-##### Example
+#### Example
 
 You can use the examples below. It is recommended that you change the font.
 

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -277,6 +277,17 @@
       "required": false,
       "type": { "name": "boolean" }
     },
+    "orientation": {
+      "defaultValue": { "value": "\"portrait\"" },
+      "description": "Force rendering in particular orientation",
+      "name": "orientation",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
+        "name": "BasePickerProps"
+      },
+      "required": false,
+      "type": { "name": "\"portrait\" | \"landscape\"" }
+    },
     "variant": {
       "defaultValue": { "value": "'dialog'" },
       "description": "Displaying variant",
@@ -286,7 +297,7 @@
         "name": "BasePickerProps"
       },
       "required": false,
-      "type": { "name": "\"dialog\" | \"inline\"" }
+      "type": { "name": "\"dialog\" | \"inline\" | \"static\"" }
     },
     "PopoverProps": {
       "defaultValue": null,
@@ -631,7 +642,7 @@
         "name": "BasePickerProps"
       },
       "required": false,
-      "type": { "name": "\"dialog\" | \"inline\"" }
+      "type": { "name": "\"dialog\" | \"inline\" | \"static\"" }
     },
     "onError": {
       "defaultValue": null,
@@ -742,6 +753,17 @@
       },
       "required": false,
       "type": { "name": "boolean" }
+    },
+    "orientation": {
+      "defaultValue": { "value": "\"portrait\"" },
+      "description": "Force rendering in particular orientation",
+      "name": "orientation",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
+        "name": "BasePickerProps"
+      },
+      "required": false,
+      "type": { "name": "\"portrait\" | \"landscape\"" }
     },
     "PopoverProps": {
       "defaultValue": null,
@@ -1253,6 +1275,17 @@
       "required": false,
       "type": { "name": "boolean" }
     },
+    "orientation": {
+      "defaultValue": { "value": "\"portrait\"" },
+      "description": "Force rendering in particular orientation",
+      "name": "orientation",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
+        "name": "BasePickerProps"
+      },
+      "required": false,
+      "type": { "name": "\"portrait\" | \"landscape\"" }
+    },
     "variant": {
       "defaultValue": { "value": "'dialog'" },
       "description": "Displaying variant",
@@ -1262,7 +1295,7 @@
         "name": "BasePickerProps"
       },
       "required": false,
-      "type": { "name": "\"dialog\" | \"inline\"" }
+      "type": { "name": "\"dialog\" | \"inline\" | \"static\"" }
     },
     "PopoverProps": {
       "defaultValue": null,
@@ -1440,7 +1473,7 @@
         "name": "BasePickerProps"
       },
       "required": false,
-      "type": { "name": "\"dialog\" | \"inline\"" }
+      "type": { "name": "\"dialog\" | \"inline\" | \"static\"" }
     },
     "onError": {
       "defaultValue": null,
@@ -1562,6 +1595,17 @@
       },
       "required": false,
       "type": { "name": "boolean" }
+    },
+    "orientation": {
+      "defaultValue": { "value": "\"portrait\"" },
+      "description": "Force rendering in particular orientation",
+      "name": "orientation",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
+        "name": "BasePickerProps"
+      },
+      "required": false,
+      "type": { "name": "\"portrait\" | \"landscape\"" }
     },
     "PopoverProps": {
       "defaultValue": null,
@@ -1917,6 +1961,17 @@
       "required": false,
       "type": { "name": "boolean" }
     },
+    "orientation": {
+      "defaultValue": { "value": "\"portrait\"" },
+      "description": "Force rendering in particular orientation",
+      "name": "orientation",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
+        "name": "BasePickerProps"
+      },
+      "required": false,
+      "type": { "name": "\"portrait\" | \"landscape\"" }
+    },
     "variant": {
       "defaultValue": { "value": "'dialog'" },
       "description": "Displaying variant",
@@ -1926,7 +1981,7 @@
         "name": "BasePickerProps"
       },
       "required": false,
-      "type": { "name": "\"dialog\" | \"inline\"" }
+      "type": { "name": "\"dialog\" | \"inline\" | \"static\"" }
     },
     "PopoverProps": {
       "defaultValue": null,
@@ -2315,7 +2370,7 @@
         "name": "BasePickerProps"
       },
       "required": false,
-      "type": { "name": "\"dialog\" | \"inline\"" }
+      "type": { "name": "\"dialog\" | \"inline\" | \"static\"" }
     },
     "onError": {
       "defaultValue": null,
@@ -2437,6 +2492,17 @@
       },
       "required": false,
       "type": { "name": "boolean" }
+    },
+    "orientation": {
+      "defaultValue": { "value": "\"portrait\"" },
+      "description": "Force rendering in particular orientation",
+      "name": "orientation",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
+        "name": "BasePickerProps"
+      },
+      "required": false,
+      "type": { "name": "\"portrait\" | \"landscape\"" }
     },
     "PopoverProps": {
       "defaultValue": null,

--- a/lib/src/DatePicker/DatePickerToolbar.tsx
+++ b/lib/src/DatePicker/DatePickerToolbar.tsx
@@ -21,6 +21,7 @@ export const DatePickerToolbar: React.FC<ToolbarComponentProps> = ({
   date,
   views,
   setOpenView,
+  isLandscape,
   openView,
 }) => {
   const utils = useUtils();
@@ -30,7 +31,12 @@ export const DatePickerToolbar: React.FC<ToolbarComponentProps> = ({
   const isYearAndMonth = React.useMemo(() => isYearAndMonthViews(views as any), [views]);
 
   return (
-    <PickerToolbar className={clsx({ [classes.toolbarCenter]: isYearOnly })}>
+    <PickerToolbar
+      isLandscape={isLandscape}
+      className={clsx({
+        [classes.toolbarCenter]: isYearOnly,
+      })}
+    >
       <ToolbarButton
         variant={isYearOnly ? 'h3' : 'subtitle1'}
         onClick={() => setOpenView('year')}
@@ -41,6 +47,7 @@ export const DatePickerToolbar: React.FC<ToolbarComponentProps> = ({
       {!isYearOnly && !isYearAndMonth && (
         <ToolbarButton
           variant="h4"
+          align={isLandscape ? 'left' : 'center'}
           onClick={() => setOpenView('date')}
           selected={openView === 'date'}
           label={utils.getDatePickerHeaderText(date)}

--- a/lib/src/DatePicker/DatePickerToolbar.tsx
+++ b/lib/src/DatePicker/DatePickerToolbar.tsx
@@ -9,9 +9,12 @@ import { isYearAndMonthViews, isYearOnlyView } from '../_helpers/date-utils';
 
 export const useStyles = makeStyles(
   {
-    toolbarCenter: {
-      flexDirection: 'row',
-      alignItems: 'center',
+    toolbar: {
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+    },
+    toolbarLandscape: {
+      padding: 16,
     },
   },
   { name: 'MuiPickersDatePickerRoot' }
@@ -34,7 +37,8 @@ export const DatePickerToolbar: React.FC<ToolbarComponentProps> = ({
     <PickerToolbar
       isLandscape={isLandscape}
       className={clsx({
-        [classes.toolbarCenter]: isYearOnly,
+        [classes.toolbar]: !isYearOnly,
+        [classes.toolbarLandscape]: isLandscape,
       })}
     >
       <ToolbarButton

--- a/lib/src/DatePicker/DatePickerToolbar.tsx
+++ b/lib/src/DatePicker/DatePickerToolbar.tsx
@@ -16,6 +16,9 @@ export const useStyles = makeStyles(
     toolbarLandscape: {
       padding: 16,
     },
+    dateLandscape: {
+      marginRight: 16,
+    },
   },
   { name: 'MuiPickersDatePickerRoot' }
 );
@@ -51,10 +54,11 @@ export const DatePickerToolbar: React.FC<ToolbarComponentProps> = ({
       {!isYearOnly && !isYearAndMonth && (
         <ToolbarButton
           variant="h4"
-          align={isLandscape ? 'left' : 'center'}
-          onClick={() => setOpenView('date')}
           selected={openView === 'date'}
+          onClick={() => setOpenView('date')}
+          align={isLandscape ? 'left' : 'center'}
           label={utils.getDatePickerHeaderText(date)}
+          className={clsx({ [classes.dateLandscape]: isLandscape })}
         />
       )}
 

--- a/lib/src/DateTimePicker/DateTimePicker.tsx
+++ b/lib/src/DateTimePicker/DateTimePicker.tsx
@@ -31,12 +31,17 @@ export type KeyboardDateTimePickerProps = WrappedKeyboardPickerProps & DateTimeP
 const defaultProps = {
   ...dateTimePickerDefaultProps,
   wider: true,
+  orientation: 'portrait' as const,
   openTo: 'date' as DateTimePickerView,
   views: ['year', 'date', 'hours', 'minutes'] as DateTimePickerView[],
 };
 
 function useOptions(props: DateTimePickerProps | KeyboardDateTimePickerProps) {
   const utils = useUtils();
+
+  if (props.orientation !== 'portrait') {
+    throw new Error('We are not supporting custom orientation for DateTimePicker yet :(');
+  }
 
   return {
     getDefaultFormat: () =>

--- a/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -13,8 +13,6 @@ import { useMeridiemMode } from '../TimePicker/TimePickerToolbar';
 export const useStyles = makeStyles(
   _ => ({
     toolbar: {
-      flexDirection: 'row',
-      alignItems: 'center',
       paddingLeft: 16,
       paddingRight: 16,
       justifyContent: 'space-around',
@@ -46,7 +44,7 @@ export const DateTimePickerToolbar: React.FC<ToolbarComponentProps> = ({
 
   return (
     <>
-      <PickerToolbar className={classes.toolbar}>
+      <PickerToolbar isLandscape={false} className={classes.toolbar}>
         <Grid container justify="center" wrap="nowrap">
           <Grid item container xs={5} justify="flex-start" direction="column">
             <div>

--- a/lib/src/Picker/Picker.tsx
+++ b/lib/src/Picker/Picker.tsx
@@ -1,15 +1,19 @@
 import * as React from 'react';
+import clsx from 'clsx';
 import Calendar from '../views/Calendar/Calendar';
 import { useUtils } from '../_shared/hooks/useUtils';
 import { useViews } from '../_shared/hooks/useViews';
 import { makeStyles } from '@material-ui/core/styles';
 import { YearSelection } from '../views/Year/YearView';
 import { MaterialUiPickersDate } from '../typings/date';
-import { MonthSelection } from '../views/Month/MonthView';
+import { BasePickerProps } from '../typings/BasePicker';
 import { TimePickerView } from '../views/Clock/ClockView';
+import { MonthSelection } from '../views/Month/MonthView';
 import { BaseTimePickerProps } from '../TimePicker/TimePicker';
 import { BaseDatePickerProps } from '../DatePicker/DatePicker';
+import { useIsLandscape } from '../_shared/hooks/useIsLandscape';
 import { datePickerDefaultProps } from '../constants/prop-types';
+import { DIALOG_WIDTH_WIDER, DIALOG_WIDTH } from '../constants/dimensions';
 
 const viewsMap = {
   year: YearSelection,
@@ -33,6 +37,7 @@ export type ToolbarComponentProps = BaseDatePickerProps &
     hideTabs?: boolean;
     dateRangeIcon?: React.ReactNode;
     timeIcon?: React.ReactNode;
+    isLandscape: boolean;
   };
 
 export interface PickerViewProps extends BaseDatePickerProps, BaseTimePickerProps {
@@ -48,16 +53,29 @@ export interface PickerViewProps extends BaseDatePickerProps, BaseTimePickerProp
 
 interface PickerProps extends PickerViewProps {
   date: MaterialUiPickersDate;
+  orientation?: BasePickerProps['orientation'];
   onChange: (date: MaterialUiPickersDate, isFinish?: boolean) => void;
 }
 
 const useStyles = makeStyles(
   {
+    container: {
+      display: 'flex',
+      flexDirection: 'column',
+    },
+    containerLandscape: {
+      flexDirection: 'row',
+    },
     pickerView: {
-      minHeight: 305,
+      overflowX: 'auto',
+      minWidth: DIALOG_WIDTH,
+      maxWidth: DIALOG_WIDTH_WIDER,
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'center',
+    },
+    pickerViewLandscape: {
+      padding: '0 8px',
     },
   },
   { name: 'MuiPickersBasePicker' }
@@ -91,17 +109,23 @@ export const Picker: React.FunctionComponent<PickerProps> = props => {
     rightArrowButtonProps,
     ToolbarComponent,
     loadingIndicator,
+    orientation,
   } = props;
 
   const utils = useUtils();
   const classes = useStyles();
+  const isLandscape = useIsLandscape(orientation);
   const { openView, setOpenView, handleChangeAndOpenNext } = useViews(views, openTo, onChange);
 
   const minDate = React.useMemo(() => utils.date(unparsedMinDate)!, [unparsedMinDate, utils]);
   const maxDate = React.useMemo(() => utils.date(unparsedMaxDate)!, [unparsedMaxDate, utils]);
 
   return (
-    <>
+    <div
+      className={clsx(classes.container, {
+        [classes.containerLandscape]: isLandscape,
+      })}
+    >
       {!disableToolbar && (
         <ToolbarComponent
           date={date}
@@ -111,11 +135,12 @@ export const Picker: React.FunctionComponent<PickerProps> = props => {
           hideTabs={hideTabs}
           dateRangeIcon={dateRangeIcon}
           timeIcon={timeIcon}
+          isLandscape={isLandscape}
           {...props}
         />
       )}
 
-      <div className={classes.pickerView}>
+      <div className={clsx(classes.pickerView, { [classes.pickerViewLandscape]: isLandscape })}>
         {openView === 'year' && (
           <YearSelection
             date={date}
@@ -173,7 +198,7 @@ export const Picker: React.FunctionComponent<PickerProps> = props => {
           />
         )}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/lib/src/Picker/Picker.tsx
+++ b/lib/src/Picker/Picker.tsx
@@ -13,7 +13,7 @@ import { BaseTimePickerProps } from '../TimePicker/TimePicker';
 import { BaseDatePickerProps } from '../DatePicker/DatePicker';
 import { useIsLandscape } from '../_shared/hooks/useIsLandscape';
 import { datePickerDefaultProps } from '../constants/prop-types';
-import { DIALOG_WIDTH_WIDER, DIALOG_WIDTH } from '../constants/dimensions';
+import { DIALOG_WIDTH_WIDER, DIALOG_WIDTH, VIEW_HEIGHT } from '../constants/dimensions';
 
 const viewsMap = {
   year: YearSelection,
@@ -67,7 +67,8 @@ const useStyles = makeStyles(
       flexDirection: 'row',
     },
     pickerView: {
-      overflowX: 'auto',
+      overflowX: 'hidden',
+      minHeight: VIEW_HEIGHT,
       minWidth: DIALOG_WIDTH,
       maxWidth: DIALOG_WIDTH_WIDER,
       display: 'flex',

--- a/lib/src/Picker/WrappedKeyboardPicker.tsx
+++ b/lib/src/Picker/WrappedKeyboardPicker.tsx
@@ -63,6 +63,7 @@ export function makeKeyboardPicker<T extends any>({
       emptyLabel,
       invalidLabel,
       timeIcon,
+      orientation,
       variant,
       disableToolbar,
       loadingIndicator,
@@ -85,6 +86,7 @@ export function makeKeyboardPicker<T extends any>({
           ToolbarComponent={ToolbarComponent}
           disableToolbar={disableToolbar}
           hideTabs={hideTabs}
+          orientation={orientation}
           ampm={ampm}
           views={views}
           openTo={openTo}

--- a/lib/src/Picker/WrappedPurePicker.tsx
+++ b/lib/src/Picker/WrappedPurePicker.tsx
@@ -55,6 +55,7 @@ export function makePurePicker<T extends any>({
       timeIcon,
       value,
       variant,
+      orientation,
       disableToolbar,
       loadingIndicator,
       ...other
@@ -73,6 +74,7 @@ export function makePurePicker<T extends any>({
       >
         <Picker
           {...pickerProps}
+          orientation={orientation}
           disableToolbar={disableToolbar}
           ToolbarComponent={ToolbarComponent}
           hideTabs={hideTabs}

--- a/lib/src/TimePicker/TimePickerToolbar.tsx
+++ b/lib/src/TimePicker/TimePickerToolbar.tsx
@@ -13,16 +13,26 @@ import { convertToMeridiem, getMeridiem } from '../_helpers/time-utils';
 
 export const useStyles = makeStyles(
   {
-    toolbar: {
-      flexDirection: 'row',
-      alignItems: 'center',
+    toolbarLandscape: {
+      flexWrap: 'wrap',
     },
-    toolbarLeftPadding: {
+    toolbarAmpmLeftPadding: {
       paddingLeft: 50,
     },
     separator: {
       margin: '0 4px 0 2px',
       cursor: 'default',
+    },
+    hourMinuteLabel: {
+      display: 'flex',
+      justifyContent: 'flex-end',
+      alignItems: 'flex-end',
+    },
+    hourMinuteLabelLandscape: {
+      marginTop: 'auto',
+    },
+    hourMinuteLabelReverse: {
+      flexDirection: 'row-reverse',
     },
     ampmSelection: {
       marginLeft: 20,
@@ -30,23 +40,18 @@ export const useStyles = makeStyles(
       display: 'flex',
       flexDirection: 'column',
     },
+    ampmLandscape: {
+      margin: '4px 0 auto',
+      flexDirection: 'row',
+      justifyContent: 'space-around',
+      flexBasis: '100%',
+    },
     ampmSelectionWithSeconds: {
       marginLeft: 15,
       marginRight: 10,
     },
     ampmLabel: {
       fontSize: 18,
-    },
-    hourMinuteLabel: {
-      display: 'flex',
-      justifyContent: 'flex-end',
-      alignItems: 'flex-end',
-    },
-    hourMinuteLabelReverse: {
-      display: 'flex',
-      justifyContent: 'flex-end',
-      alignItems: 'flex-end',
-      flexDirection: 'row-reverse',
     },
   },
   { name: 'MuiPickersTimePickerToolbar' }
@@ -77,6 +82,7 @@ const TimePickerToolbar: React.FC<ToolbarComponentProps> = ({
   ampm,
   openView,
   onChange,
+  isLandscape,
   setOpenView,
 }) => {
   const utils = useUtils();
@@ -84,19 +90,25 @@ const TimePickerToolbar: React.FC<ToolbarComponentProps> = ({
   const classes = useStyles();
   const { meridiemMode, handleMeridiemChange } = useMeridiemMode(date, ampm, onChange);
 
-  const hourMinuteClassName =
-    theme.direction === 'rtl' ? classes.hourMinuteLabelReverse : classes.hourMinuteLabel;
+  const clockTypographyVariant = isLandscape ? 'h3' : 'h2';
 
   return (
     <PickerToolbar
-      className={clsx(classes.toolbar, {
-        [classes.toolbarLeftPadding]: ampm,
+      isLandscape={isLandscape}
+      className={clsx({
+        [classes.toolbarLandscape]: isLandscape,
+        [classes.toolbarAmpmLeftPadding]: ampm && !isLandscape,
       })}
     >
-      <div className={hourMinuteClassName}>
+      <div
+        className={clsx(classes.hourMinuteLabel, {
+          [classes.hourMinuteLabelLandscape]: isLandscape,
+          [classes.hourMinuteLabelReverse]: theme.direction === 'rtl',
+        })}
+      >
         {arrayIncludes(views, 'hours') && (
           <ToolbarButton
-            variant="h2"
+            variant={clockTypographyVariant}
             onClick={() => setOpenView(ClockType.HOURS)}
             selected={openView === ClockType.HOURS}
             label={utils.getHourText(date, Boolean(ampm))}
@@ -104,12 +116,17 @@ const TimePickerToolbar: React.FC<ToolbarComponentProps> = ({
         )}
 
         {arrayIncludes(views, ['hours', 'minutes']) && (
-          <ToolbarText variant="h2" label=":" selected={false} className={classes.separator} />
+          <ToolbarText
+            label=":"
+            variant={clockTypographyVariant}
+            selected={false}
+            className={classes.separator}
+          />
         )}
 
         {arrayIncludes(views, 'minutes') && (
           <ToolbarButton
-            variant="h2"
+            variant={clockTypographyVariant}
             onClick={() => setOpenView(ClockType.MINUTES)}
             selected={openView === ClockType.MINUTES}
             label={utils.getMinuteText(date)}
@@ -133,6 +150,7 @@ const TimePickerToolbar: React.FC<ToolbarComponentProps> = ({
       {ampm && (
         <div
           className={clsx(classes.ampmSelection, {
+            [classes.ampmLandscape]: isLandscape,
             [classes.ampmSelectionWithSeconds]: arrayIncludes(views, 'seconds'),
           })}
         >

--- a/lib/src/__tests__/e2e/Theme.test.tsx
+++ b/lib/src/__tests__/e2e/Theme.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from '../test-utils';
+import { DatePicker } from '../../DatePicker';
 import { createMuiTheme } from '@material-ui/core';
 import { ThemeProvider } from '@material-ui/styles';
 import { DateTimePicker } from '../../DateTimePicker/DateTimePicker';
@@ -15,6 +16,14 @@ test('Should renders without crash in dark theme', () => {
     <ThemeProvider theme={theme}>
       <DateTimePicker open openTo="hours" value={null} onChange={jest.fn()} />
     </ThemeProvider>
+  );
+
+  expect(component).toBeTruthy();
+});
+
+test('Should render component with different orientation', () => {
+  const component = mount(
+    <DatePicker open orientation="landscape" value={null} onChange={jest.fn()} />
   );
 
   expect(component).toBeTruthy();

--- a/lib/src/_shared/ModalDialog.tsx
+++ b/lib/src/_shared/ModalDialog.tsx
@@ -4,7 +4,7 @@ import Button from '@material-ui/core/Button';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import Dialog, { DialogProps } from '@material-ui/core/Dialog';
-import { DIALOG_WIDTH, DIALOG_WIDTH_WIDER } from '../constants/dimensions';
+import { DIALOG_WIDTH } from '../constants/dimensions';
 import { createStyles, WithStyles, withStyles } from '@material-ui/core/styles';
 
 export interface ModalDialogProps extends DialogProps {

--- a/lib/src/_shared/ModalDialog.tsx
+++ b/lib/src/_shared/ModalDialog.tsx
@@ -90,14 +90,13 @@ ModalDialog.displayName = 'ModalDialog';
 export const styles = createStyles({
   dialogRoot: {
     minWidth: DIALOG_WIDTH,
-    maxWidth: DIALOG_WIDTH_WIDER,
+    // maxWidth: DIALOG_WIDTH_WIDER,
   },
   dialogRootWider: {
-    minWidth: DIALOG_WIDTH_WIDER,
+    // minWidth: DIALOG_WIDTH_WIDER,
   },
   dialog: {
     // minHeight: dialogHeight,
-    overflow: 'hidden',
 
     '&:first-child': {
       padding: 0,

--- a/lib/src/_shared/ModalDialog.tsx
+++ b/lib/src/_shared/ModalDialog.tsx
@@ -96,8 +96,6 @@ export const styles = createStyles({
     // minWidth: DIALOG_WIDTH_WIDER,
   },
   dialog: {
-    // minHeight: dialogHeight,
-
     '&:first-child': {
       padding: 0,
     },

--- a/lib/src/_shared/PickerToolbar.tsx
+++ b/lib/src/_shared/PickerToolbar.tsx
@@ -8,8 +8,8 @@ export const useStyles = makeStyles(
   theme => ({
     toolbar: {
       display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'flex-start',
+      flexDirection: 'row',
+      alignItems: 'center',
       justifyContent: 'center',
       height: 100,
       backgroundColor:
@@ -20,7 +20,7 @@ export const useStyles = makeStyles(
     toolbarLandscape: {
       height: 'auto',
       maxWidth: 150,
-      padding: 16,
+      padding: 8,
       justifyContent: 'flex-start',
     },
   }),

--- a/lib/src/_shared/PickerToolbar.tsx
+++ b/lib/src/_shared/PickerToolbar.tsx
@@ -17,19 +17,33 @@ export const useStyles = makeStyles(
           ? theme.palette.primary.main
           : theme.palette.background.default,
     },
+    toolbarLandscape: {
+      height: 'auto',
+      maxWidth: 150,
+      padding: 16,
+      justifyContent: 'flex-start',
+    },
   }),
   { name: 'MuiPickersToolbar' }
 );
 
-const PickerToolbar: React.SFC<ExtendMui<ToolbarProps>> = ({
+interface PickerToolbarProps extends ExtendMui<ToolbarProps> {
+  isLandscape: boolean;
+}
+
+const PickerToolbar: React.SFC<PickerToolbarProps> = ({
   children,
+  isLandscape,
   className = null,
   ...other
 }) => {
   const classes = useStyles();
 
   return (
-    <Toolbar className={clsx(classes.toolbar, className)} {...other}>
+    <Toolbar
+      className={clsx(classes.toolbar, { [classes.toolbarLandscape]: isLandscape }, className)}
+      {...other}
+    >
       {children}
     </Toolbar>
   );

--- a/lib/src/_shared/ToolbarButton.tsx
+++ b/lib/src/_shared/ToolbarButton.tsx
@@ -13,6 +13,7 @@ export interface ToolbarButtonProps
   variant: TypographyProps['variant'];
   selected: boolean;
   label: string;
+  align?: TypographyProps['align'];
   typographyClassName?: string;
 }
 
@@ -22,12 +23,14 @@ const ToolbarButton: React.FunctionComponent<ToolbarButtonProps> = ({
   label,
   selected,
   variant,
+  align,
   typographyClassName,
   ...other
 }) => {
   return (
     <Button variant="text" className={clsx(classes.toolbarBtn, className)} {...other}>
       <ToolbarText
+        align={align}
         className={typographyClassName}
         variant={variant}
         label={label}

--- a/lib/src/_shared/hooks/useIsLandscape.tsx
+++ b/lib/src/_shared/hooks/useIsLandscape.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { BasePickerProps } from '../../typings/BasePicker';
+
+const getOrientation = () =>
+  typeof window !== 'undefined' && Math.abs(window.screen.orientation.angle) === 90
+    ? 'landscape'
+    : 'portrait';
+
+export function useIsLandscape(customOrientation?: BasePickerProps['orientation']) {
+  const [orientation, setOrientation] = React.useState<BasePickerProps['orientation']>(
+    getOrientation()
+  );
+
+  const eventHandler = React.useCallback(() => setOrientation(getOrientation()), []);
+
+  React.useEffect(() => {
+    window.addEventListener('orientationchange', eventHandler);
+    return () => window.removeEventListener('orientationchange', eventHandler);
+  }, [eventHandler]);
+
+  const orientationToUse = customOrientation || orientation;
+  return orientationToUse === 'landscape';
+}

--- a/lib/src/_shared/hooks/useIsLandscape.tsx
+++ b/lib/src/_shared/hooks/useIsLandscape.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useIsomorphicEffect } from './useKeyDown';
 import { BasePickerProps } from '../../typings/BasePicker';
 
 const getOrientation = () =>
@@ -16,7 +17,7 @@ export function useIsLandscape(customOrientation?: BasePickerProps['orientation'
 
   const eventHandler = React.useCallback(() => setOrientation(getOrientation()), []);
 
-  React.useEffect(() => {
+  useIsomorphicEffect(() => {
     window.addEventListener('orientationchange', eventHandler);
     return () => window.removeEventListener('orientationchange', eventHandler);
   }, [eventHandler]);

--- a/lib/src/_shared/hooks/useIsLandscape.tsx
+++ b/lib/src/_shared/hooks/useIsLandscape.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 import { BasePickerProps } from '../../typings/BasePicker';
 
 const getOrientation = () =>
-  typeof window !== 'undefined' && Math.abs(window.screen.orientation.angle) === 90
+  typeof window !== 'undefined' &&
+  window.screen &&
+  window.orientation &&
+  Math.abs(window.screen.orientation.angle) === 90
     ? 'landscape'
     : 'portrait';
 

--- a/lib/src/_shared/hooks/useKeyDown.ts
+++ b/lib/src/_shared/hooks/useKeyDown.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
-const useIsomorphicEffect = typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect;
+export const useIsomorphicEffect =
+  typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect;
 
 type KeyHandlers = Record<KeyboardEvent['key'], () => void>;
 

--- a/lib/src/constants/dimensions.ts
+++ b/lib/src/constants/dimensions.ts
@@ -1,3 +1,5 @@
 export const DIALOG_WIDTH = 310;
 
 export const DIALOG_WIDTH_WIDER = 325;
+
+export const VIEW_HEIGHT = 305;

--- a/lib/src/typings/BasePicker.tsx
+++ b/lib/src/typings/BasePicker.tsx
@@ -45,6 +45,8 @@ export interface BasePickerProps {
    * @default false
    */
   disableToolbar?: boolean;
+  /** Force rendering in particular orientation */
+  orientation?: 'portrait' | 'landscape';
   variant?: WrapperVariant;
   mergePreviousDateOnChange?: boolean;
   forwardedRef?: any;

--- a/lib/src/typings/BasePicker.tsx
+++ b/lib/src/typings/BasePicker.tsx
@@ -45,7 +45,10 @@ export interface BasePickerProps {
    * @default false
    */
   disableToolbar?: boolean;
-  /** Force rendering in particular orientation */
+  /**
+   * Force rendering in particular orientation
+   * @default "portrait"
+   */
   orientation?: 'portrait' | 'landscape';
   variant?: WrapperVariant;
   mergePreviousDateOnChange?: boolean;

--- a/lib/src/wrappers/StaticWrapper.tsx
+++ b/lib/src/wrappers/StaticWrapper.tsx
@@ -6,7 +6,7 @@ const useStyles = makeStyles(
   theme => ({
     staticWrapperRoot: {
       overflow: 'hidden',
-      width: DIALOG_WIDTH,
+      minWidth: DIALOG_WIDTH,
       display: 'flex',
       flexDirection: 'column',
       backgroundColor: theme.palette.background.paper,


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

This PR closes #766  <!-- Please refer issue number here, if exists -->

## Description
This PR **FINALLY** adds support of landscape/portrait orientation. Right now only for DatePicker and TimePicker. Also adds scrolls in portrait mode for small screens to make possible enter the date. 

DatePicker:
![image](https://user-images.githubusercontent.com/16926049/61188165-edad6080-a683-11e9-8a73-3e8efd026dd3.png)


Timepicker:
![image](https://user-images.githubusercontent.com/16926049/61188161-e1c19e80-a683-11e9-8423-a3de81f16e80.png)
