### PR TITLE
Update CSS overrides example

### DIFF
--- a/docs/pages/guides/CssOverrides.example.jsx
+++ b/docs/pages/guides/CssOverrides.example.jsx
@@ -22,8 +22,11 @@ const materialTheme = createMuiTheme({
       day: {
         color: lightBlue.A700,
       },
-      isSelected: {
+      daySelected: {
         backgroundColor: lightBlue['400'],
+      },
+      dayDisabled: {
+        color: lightBlue['100'],
       },
       current: {
         color: lightBlue['900'],
@@ -46,6 +49,7 @@ function CssOverrides() {
         label="Light blue picker"
         value={selectedDate}
         onChange={handleDateChange}
+        shouldDisableDate={day => day.getDay() === 0}
         animateYearScrolling={false}
       />
     </ThemeProvider>


### PR DESCRIPTION
## Description
After updating MUI pickers our customized theme was not applied anymore and a warning was shown in the console about overriding unknown style `isSelected` for `MuiPickersDay`. This change was not mentioned in the release notes and the docs are still showing an example using `isSelected`.

This pull request fixes the docs and adds an example of `dayDisabled` style.