### PR TITLE
Support auto detection of orientation change for safari

### DIFF
--- a/lib/src/_shared/hooks/useIsLandscape.tsx
+++ b/lib/src/_shared/hooks/useIsLandscape.tsx
@@ -2,13 +2,22 @@ import * as React from 'react';
 import { useIsomorphicEffect } from './useKeyDown';
 import { BasePickerProps } from '../../typings/BasePicker';
 
-const getOrientation = () =>
-  typeof window !== 'undefined' &&
-  window.screen &&
-  window.screen.orientation &&
-  Math.abs(window.screen.orientation.angle) === 90
-    ? 'landscape'
-    : 'portrait';
+const getOrientation = () => {
+  if (typeof window === 'undefined') {
+    return 'portrait';
+  }
+
+  if (window.screen && window.screen.orientation && window.screen.orientation.angle) {
+    return Math.abs(window.screen.orientation.angle) === 90 ? 'landscape' : 'portrait';
+  }
+
+  // Support IOS safari
+  if (window.orientation) {
+    return Math.abs(Number(window.orientation)) === 90 ? 'landscape' : 'portrait';
+  }
+
+  return 'portrait';
+};
 
 export function useIsLandscape(customOrientation?: BasePickerProps['orientation']) {
   const [orientation, setOrientation] = React.useState<BasePickerProps['orientation']>(


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

This PR closes #1195  <!-- Please refer issue number here, if exists -->

## Description
Use deprecated `window.orientation` to support ios devices :) 