### PR TITLE
Remove direct `@material-ui/core` imports.

### DIFF
--- a/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
+import Grid from '@material-ui/core/Grid';
 import ToolbarText from '../_shared/ToolbarText';
 import PickerToolbar from '../_shared/PickerToolbar';
 import ToolbarButton from '../_shared/ToolbarButton';
 import DateTimePickerTabs from './DateTimePickerTabs';
-import { Grid } from '@material-ui/core';
 import { useUtils } from '../_shared/hooks/useUtils';
 import { DateTimePickerView } from './DateTimePicker';
 import { ToolbarComponentProps } from '../Picker/Picker';

--- a/lib/src/_helpers/text-field-helper.ts
+++ b/lib/src/_helpers/text-field-helper.ts
@@ -1,5 +1,4 @@
 import { DatePickerProps } from '..';
-import { Omit } from '@material-ui/core';
 import { IUtils } from '@date-io/core/IUtils';
 import { ParsableDate } from '../constants/prop-types';
 import { BasePickerProps } from '../typings/BasePicker';

--- a/lib/src/_shared/WithUtils.tsx
+++ b/lib/src/_shared/WithUtils.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Omit } from '@material-ui/core';
 import { useUtils } from './hooks/useUtils';
 import { IUtils } from '@date-io/core/IUtils';
 import { MaterialUiPickersDate } from '../typings/date';

--- a/lib/src/_shared/hooks/useKeyboardPickerState.ts
+++ b/lib/src/_shared/hooks/useKeyboardPickerState.ts
@@ -1,5 +1,4 @@
 import { useUtils } from './useUtils';
-import { Omit } from '@material-ui/core';
 import { IUtils } from '@date-io/core/IUtils';
 import { BasePickerProps } from '../../typings/BasePicker';
 import { MaterialUiPickersDate } from '../../typings/date';

--- a/lib/src/typings/extendMui.ts
+++ b/lib/src/typings/extendMui.ts
@@ -1,4 +1,3 @@
-import { Omit } from '@material-ui/core';
 /**
  * All standard components exposed by `material-ui` are `StyledComponents` with
  * certain `classes`, on which one can also set a top-level `className` and inline

--- a/lib/src/views/Calendar/Calendar.tsx
+++ b/lib/src/views/Calendar/Calendar.tsx
@@ -5,7 +5,7 @@ import DayWrapper from './DayWrapper';
 import CalendarHeader from './CalendarHeader';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import SlideTransition, { SlideDirection } from './SlideTransition';
-import { Theme } from '@material-ui/core';
+import { Theme } from '@material-ui/core/styles';
 import { MaterialUiPickersDate } from '../../typings/date';
 import { runKeyHandler } from '../../_shared/hooks/useKeyDown';
 import { IconButtonProps } from '@material-ui/core/IconButton';

--- a/lib/src/views/Clock/ClockPointer.tsx
+++ b/lib/src/views/Clock/ClockPointer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import ClockType, { ClockViewType } from '../../constants/ClockType';
-import { Theme } from '@material-ui/core';
+import { Theme } from '@material-ui/core/styles';
 import { withStyles, createStyles, WithStyles } from '@material-ui/core/styles';
 
 export interface ClockPointerProps extends WithStyles<typeof styles> {


### PR DESCRIPTION
## Description

After #1236, a few imports were remaining, remove those imports.
Also, use type `Omit` from typescript utility types.
This will ensure zero direct references to `@material-ui/core`.

<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->
