### PR TITLE
[useKeyDown] Change key event handlers only when active state changes

### DIFF
--- a/lib/src/_shared/hooks/useKeyDown.ts
+++ b/lib/src/_shared/hooks/useKeyDown.ts
@@ -16,19 +16,19 @@ export function runKeyHandler(e: KeyboardEvent, keyHandlers: KeyHandlers) {
 
 export function useKeyDown(active: boolean, keyHandlers: KeyHandlers) {
   const keyHandlersRef = React.useRef(keyHandlers);
-  useIsomorphicEffect(() => {
+  React.useEffect(() => {
     keyHandlersRef.current = keyHandlers;
   });
 
   React.useEffect(() => {
     if (active) {
       const handleKeyDown = (event: KeyboardEvent) => {
-        runKeyHandler(event, keyHandlers);
+        runKeyHandler(event, keyHandlersRef.current);
       };
       window.addEventListener('keydown', handleKeyDown);
       return () => {
         window.removeEventListener('keydown', handleKeyDown);
       };
     }
-  }, [active, keyHandlers]);
+  }, [active]);
 }


### PR DESCRIPTION
I noticed that the hook re-registers the keydown/up event handlers whenever it's called (React useEffect uses `==` to compare the dependencies, and `{} != {}`), but it only needs to do that when the active state changes. The code was almost correct, it was using a ref (`keyHandlersRef`) to hold the key handlers, but that ref was not being used from inside the DOM event handlers.

I also changed useIsomorphicEffect to useEffect because there is no need to run that immediately, since it doesn't affect layout.