### PR TITLE
[Fix 1311] Add missing event props to pickers

### DIFF
--- a/lib/src/DatePicker/DatePicker.tsx
+++ b/lib/src/DatePicker/DatePicker.tsx
@@ -13,6 +13,7 @@ import {
   WithPureInputProps,
   makePickerWithState,
 } from '../Picker/makePickerWithState';
+import { InputProps as StandardInputProps } from "@material-ui/core/Input"
 
 export type DatePickerView = 'year' | 'date' | 'month';
 
@@ -61,6 +62,10 @@ export interface DatePickerViewsProps extends BaseDatePickerProps {
   views?: DatePickerView[];
   /** First view to show in DatePicker */
   openTo?: DatePickerView;
+  
+  onBlur?: StandardInputProps["onBlur"]
+  onChange?: StandardInputProps["onChange"]
+  onFocus?: StandardInputProps["onFocus"]
 }
 
 export type DatePickerProps = WithPureInputProps & DatePickerViewsProps;


### PR DESCRIPTION
This PR closes https://github.com/mui-org/material-ui-pickers/issues/1311

## Description
This PR just adds the missing standard input props
