### PR TITLE
Fix clock number position issue

### DIFF
--- a/lib/src/views/Clock/ClockNumber.tsx
+++ b/lib/src/views/Clock/ClockNumber.tsx
@@ -47,7 +47,7 @@ export const useStyles = makeStyles(
         height: 32,
         userSelect: 'none',
         position: 'absolute',
-        left: `calc(50% - ${size / 2}px)`,
+        left: `calc((100% - ${typeof size === 'number' ? `${size}px` : size}) / 2)`,
         display: 'inline-flex',
         justifyContent: 'center',
         alignItems: 'center',


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

This PR closes #1321 <!-- Please refer issue number here, if exists -->

## Description

If overwrite theme spacing as below at https://material-ui.com/customization/spacing/#custom-spacing. The clock number position is not right.

```
const theme = createMuiTheme({
  spacing: factor => `${0.25 * factor}rem`, // (Bootstrap strategy)
});
```

## Screenshot

![image](https://user-images.githubusercontent.com/3853678/65569354-e530aa80-df8f-11e9-8bb4-3f5208874bbe.png)

