### PR TITLE
Added error handling for scrollIntoView (fix for #1365)

### DIFF
--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -62,7 +62,7 @@
     },
     "showTodayButton": {
       "defaultValue": {
-        "value": "false"
+        "value": false
       },
       "description": "If true today button will be displayed <b>Note*</b> that clear button has higher priority",
       "name": "showTodayButton",
@@ -77,7 +77,7 @@
     },
     "clearable": {
       "defaultValue": {
-        "value": "false"
+        "value": false
       },
       "description": "Show clear action in picker dialog",
       "name": "clearable",
@@ -3768,7 +3768,9 @@
       }
     },
     "minDate": {
-      "defaultValue": null,
+      "defaultValue": {
+        "value": null
+      },
       "description": "Min date",
       "name": "minDate",
       "parent": {
@@ -3781,7 +3783,9 @@
       }
     },
     "maxDate": {
-      "defaultValue": null,
+      "defaultValue": {
+        "value": null
+      },
       "description": "Max date",
       "name": "maxDate",
       "parent": {
@@ -3795,7 +3799,7 @@
     },
     "disablePast": {
       "defaultValue": {
-        "value": "false"
+        "value": false
       },
       "description": "Disable past dates",
       "name": "disablePast",
@@ -3810,7 +3814,7 @@
     },
     "disableFuture": {
       "defaultValue": {
-        "value": "false"
+        "value": false
       },
       "description": "Disable future dates",
       "name": "disableFuture",
@@ -3864,7 +3868,7 @@
     },
     "allowKeyboardControl": {
       "defaultValue": {
-        "value": "true"
+        "value": true
       },
       "description": "Enables keyboard listener for moving between days in calendar",
       "name": "allowKeyboardControl",
@@ -3972,7 +3976,7 @@
     },
     "ampm": {
       "defaultValue": {
-        "value": "true"
+        "value": true
       },
       "description": "12h/24h clock mode",
       "name": "ampm",
@@ -3987,7 +3991,7 @@
     },
     "minutesStep": {
       "defaultValue": {
-        "value": "1"
+        "value": 1
       },
       "description": "Minutes step",
       "name": "minutesStep",
@@ -4069,7 +4073,7 @@
     },
     "ampm": {
       "defaultValue": {
-        "value": "true"
+        "value": true
       },
       "description": "12h/24h clock mode",
       "name": "ampm",
@@ -4084,7 +4088,7 @@
     },
     "minutesStep": {
       "defaultValue": {
-        "value": "1"
+        "value": 1
       },
       "description": "Minutes step",
       "name": "minutesStep",

--- a/lib/src/views/Year/YearView.tsx
+++ b/lib/src/views/Year/YearView.tsx
@@ -54,10 +54,12 @@ export const YearSelection: React.FC<YearSelectionProps> = ({
           behavior: animateYearScrolling ? 'smooth' : 'auto',
         });
       } catch (err) {
-        selectedYearRef.current.parentElement.scrollTo(
-          0,
-          selectedYearRef.current.offsetTop - selectedYearRef.current.offsetHeight * 6
-        );
+        if (selectedYearRef.current.parentElement) {
+          selectedYearRef.current.parentElement.scrollTo(
+            0,
+            selectedYearRef.current.offsetTop - selectedYearRef.current.offsetHeight * 6
+          );
+        }
       }
     }
   }, []); // eslint-disable-line

--- a/lib/src/views/Year/YearView.tsx
+++ b/lib/src/views/Year/YearView.tsx
@@ -44,10 +44,21 @@ export const YearSelection: React.FC<YearSelectionProps> = ({
 
   React.useEffect(() => {
     if (selectedYearRef.current && selectedYearRef.current.scrollIntoView) {
-      selectedYearRef.current.scrollIntoView({
-        block: currentVariant === 'static' ? 'nearest' : 'center',
-        behavior: animateYearScrolling ? 'smooth' : 'auto',
-      });
+      /*
+        Before Firefox 58, nearest and center values for the block option were unsupported.
+        Using either of these two values causes an error to be thrown.
+      */
+      try {
+        selectedYearRef.current.scrollIntoView({
+          block: currentVariant === 'static' ? 'nearest' : 'center',
+          behavior: animateYearScrolling ? 'smooth' : 'auto',
+        });
+      } catch (err) {
+        selectedYearRef.current.parentElement.scrollTo(
+          0,
+          selectedYearRef.current.offsetTop - selectedYearRef.current.offsetHeight * 6
+        );
+      }
     }
   }, []); // eslint-disable-line
 


### PR DESCRIPTION
This PR closes https://github.com/mui-org/material-ui-pickers/issues/1365

## Description

Added error handling for the scrollIntoView method, which errors in Firefox versions before 58 (according to the [Material UI docs](https://material-ui.com/getting-started/supported-platforms/) Firefox versions >= 52 are supported).

How to test this:

* Download and use Firefox v52: https://ftp.mozilla.org/pub/firefox/releases/
* Go here to see the error: https://material-ui-pickers.dev/demo/datepicker

You'll see it gives a white screen, look in the console to see the ScrollIntoView error message.

In this PR, do the same thing except go here: http://localhost:3000/demo/datepicker - no error occurs. Open a DatePicker and click the Year. See that you can select a year just fine.