### PR TITLE
Fix type declaration conflicts for TypeScript 3.7

### DIFF
--- a/lib/src/DatePicker/index.ts
+++ b/lib/src/DatePicker/index.ts
@@ -1,7 +1,3 @@
-import { DatePickerProps, KeyboardDatePickerProps } from './DatePicker';
-
-export type DatePickerProps = DatePickerProps;
-
-export type KeyboardDatePickerProps = KeyboardDatePickerProps;
+export { DatePickerProps, KeyboardDatePickerProps } from './DatePicker';
 
 export { KeyboardDatePicker, DatePicker } from './DatePicker';

--- a/lib/src/DateTimePicker/index.ts
+++ b/lib/src/DateTimePicker/index.ts
@@ -1,7 +1,3 @@
-import { DateTimePickerProps, KeyboardDateTimePickerProps } from './DateTimePicker';
-
-export type DateTimePickerProps = DateTimePickerProps;
-
-export type KeyboardDateTimePickerProps = KeyboardDateTimePickerProps;
+export { DateTimePickerProps, KeyboardDateTimePickerProps } from './DateTimePicker';
 
 export { KeyboardDateTimePicker, DateTimePicker } from './DateTimePicker';

--- a/lib/src/TimePicker/index.tsx
+++ b/lib/src/TimePicker/index.tsx
@@ -1,7 +1,3 @@
-import { KeyboardTimePickerProps, TimePickerProps } from './TimePicker';
-
-export type TimePickerProps = TimePickerProps;
-
-export type KeyboardTimePickerProps = KeyboardTimePickerProps;
+export { KeyboardTimePickerProps, TimePickerProps } from './TimePicker';
 
 export { KeyboardTimePicker, TimePicker } from './TimePicker';

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,21 +1,8 @@
-import { MaterialUiPickersDate } from './typings/date';
-import { KeyboardTimePickerProps } from './TimePicker';
-import { DatePickerProps, KeyboardDatePickerProps } from './DatePicker';
-import { DateTimePickerProps, KeyboardDateTimePickerProps } from './DateTimePicker';
-
-export type TimePickerProps = KeyboardTimePickerProps;
-
-export type KeyboardTimePickerProps = KeyboardTimePickerProps;
-
-export type DatePickerProps = DatePickerProps;
-
-export type KeyboardDatePickerProps = KeyboardDatePickerProps;
-
-export type DateTimePickerProps = DateTimePickerProps;
-
-export type KeyboardDateTimePickerProps = KeyboardDateTimePickerProps;
-
-export type MaterialUiPickersDate = MaterialUiPickersDate;
+export { MaterialUiPickersDate } from './typings/date';
+export { KeyboardTimePickerProps } from './TimePicker';
+export { KeyboardTimePickerProps as TimePickerProps } from './TimePicker';
+export { DatePickerProps, KeyboardDatePickerProps } from './DatePicker';
+export { DateTimePickerProps, KeyboardDateTimePickerProps } from './DateTimePicker';
 
 export { DatePicker, KeyboardDatePicker } from './DatePicker';
 


### PR DESCRIPTION
This PR closes #1378

## Description

Change type export declarations to support TS 3.7 which introduces this breaking change: https://devblogs.microsoft.com/typescript/announcing-typescript-3-7-rc/#local-and-imported-type-declarations-now-conflict