### PR TITLE
[docs] Update date-fns example

### DIFF
--- a/docs/pages/demo/datepicker/index.mdx
+++ b/docs/pages/demo/datepicker/index.mdx
@@ -30,7 +30,7 @@ color and type weight.
 It is recommended to use keyboard input with mask for a better desktop experience. Make sure that mask will be automatically
 generated from passed `format`. It's recommended to use only robust formats for keyboard input.
 
-> Make sure that `onChange` have second parameter here. So if you will not do `onChange={date => handleDateChange(date)}` you will get console warning [useState hook dose not accept a second callback argument](https://github.com/facebook/react/issues/14174)
+> Make sure that `onChange` has a second parameter here. So if you will not do `onChange={date => handleDateChange(date)}` you will get the console warning that [useState hook does not accept a second callback argument.](https://github.com/facebook/react/issues/14174)
 
 <Example source={KeyboardDatePicker} />
 

--- a/docs/pages/demo/datetime-picker/index.mdx
+++ b/docs/pages/demo/datetime-picker/index.mdx
@@ -25,7 +25,7 @@ This component combines Material Design date & time selection components. It all
 
 #### Customization
 
-Applied almost all customizations, that are available for date & time pickers
+Here are some examples of heavily customized date & time pickers
 
 <Example source={CustomDateTimePicker} />
 

--- a/docs/pages/localization/Date-fns-customized.example.jsx
+++ b/docs/pages/localization/Date-fns-customized.example.jsx
@@ -20,7 +20,7 @@ class RuLocalizedUtils extends DateFnsUtils {
   }
 
   getDatePickerHeaderText(date) {
-    return format(date, 'dd MMMM, EEEE', { locale: this.locale });
+    return format(date, 'dd MMMM', { locale: this.locale });
   }
 }
 
@@ -39,7 +39,7 @@ const localeUtilsMap = {
 const localeFormatMap = {
   en: 'MMMM d, yyyy',
   fr: 'd MMM yyyy',
-  ru: 'd MMMM yyyy',
+  ru: 'd MMM yyyy',
 };
 
 const localeCancelLabelMap = {

--- a/docs/pages/localization/Date-fns-customized.example.jsx
+++ b/docs/pages/localization/Date-fns-customized.example.jsx
@@ -1,0 +1,106 @@
+import format from 'date-fns/format';
+import frLocale from 'date-fns/locale/fr';
+import ruLocale from 'date-fns/locale/ru';
+import enLocale from 'date-fns/locale/en-US';
+import DateFnsUtils from '@date-io/date-fns';
+import MoreIcon from '@material-ui/icons/MoreVert';
+import React, { useState, useCallback } from 'react';
+import { IconButton, Menu, MenuItem } from '@material-ui/core';
+import { DatePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
+
+const localeMap = {
+  en: enLocale,
+  fr: frLocale,
+  ru: ruLocale,
+};
+
+class RuLocalizedUtils extends DateFnsUtils {
+  getCalendarHeaderText(date) {
+    return format(date, 'LLLL', { locale: this.locale });
+  }
+
+  getDatePickerHeaderText(date) {
+    return format(date, 'dd MMMM, EEEE', { locale: this.locale });
+  }
+}
+
+class FrLocalizedUtils extends DateFnsUtils {
+  getDatePickerHeaderText(date) {
+    return format(date, 'd MMM yyyy', { locale: this.locale });
+  }
+}
+
+const localeUtilsMap = {
+  en: DateFnsUtils,
+  fr: FrLocalizedUtils,
+  ru: RuLocalizedUtils,
+};
+
+const localeFormatMap = {
+  en: 'MMMM d, yyyy',
+  fr: 'd MMM yyyy',
+  ru: 'd MMMM yyyy',
+};
+
+const localeCancelLabelMap = {
+  en: 'cancel',
+  fr: 'annuler',
+  ru: 'отмена',
+};
+
+function DateFnsLocalizationExample() {
+  const [locale, setLocale] = useState('ru');
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [selectedDate, handleDateChange] = useState(new Date());
+
+  const handleMenuOpen = useCallback(e => {
+    e.stopPropagation();
+    setAnchorEl(e.currentTarget);
+  }, []);
+
+  const selectLocale = useCallback(locale => {
+    setLocale(locale);
+    setAnchorEl(null);
+  }, []);
+
+  return (
+    <MuiPickersUtilsProvider utils={localeUtilsMap[locale]} locale={localeMap[locale]}>
+      <DatePicker
+        value={selectedDate}
+        onChange={handleDateChange}
+        format={localeFormatMap[locale]}
+        cancelLabel={localeCancelLabelMap[locale]}
+        InputProps={{
+          endAdornment: (
+            <IconButton
+              aria-label="Select locale"
+              onClick={handleMenuOpen}
+              aria-owns={anchorEl ? 'locale-menu' : undefined}
+            >
+              <MoreIcon />
+            </IconButton>
+          ),
+        }}
+      />
+
+      <Menu
+        id="locale-menu"
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={() => setAnchorEl(null)}
+      >
+        {Object.keys(localeMap).map(localeItem => (
+          <MenuItem
+            key={localeItem}
+            selected={localeItem === locale}
+            onClick={() => selectLocale(localeItem)}
+          >
+            {localeItem}
+          </MenuItem>
+        ))}
+      </Menu>
+    </MuiPickersUtilsProvider>
+  );
+}
+
+export default DateFnsLocalizationExample;

--- a/docs/pages/localization/Date-fns.example.jsx
+++ b/docs/pages/localization/Date-fns.example.jsx
@@ -1,7 +1,8 @@
+import format from 'date-fns/format';
 import frLocale from 'date-fns/locale/fr';
 import ruLocale from 'date-fns/locale/ru';
-import DateFnsUtils from '@date-io/date-fns';
 import enLocale from 'date-fns/locale/en-US';
+import DateFnsUtils from '@date-io/date-fns';
 import MoreIcon from '@material-ui/icons/MoreVert';
 import React, { useState, useCallback } from 'react';
 import { IconButton, Menu, MenuItem } from '@material-ui/core';
@@ -11,6 +12,40 @@ const localeMap = {
   en: enLocale,
   fr: frLocale,
   ru: ruLocale,
+};
+
+class RuLocalizedUtils extends DateFnsUtils {
+  getCalendarHeaderText(date) {
+    return format(date, 'LLLL', { locale: this.locale });
+  }
+
+  getDatePickerHeaderText(date) {
+    return format(date, 'dd MMMM, EEEE', { locale: this.locale });
+  }
+}
+
+class FrLocalizedUtils extends DateFnsUtils {
+  getDatePickerHeaderText(date) {
+    return format(date, 'd MMM yyyy', { locale: this.locale });
+  }
+}
+
+const localeUtilsMap = {
+  en: DateFnsUtils,
+  fr: FrLocalizedUtils,
+  ru: RuLocalizedUtils,
+};
+
+const localeFormatMap = {
+  en: 'MMMM d, yyyy',
+  fr: 'd MMM yyyy',
+  ru: 'd MMMM yyyy',
+};
+
+const localeCancelLabelMap = {
+  en: 'cancel',
+  fr: 'annuler',
+  ru: 'отмена',
 };
 
 function DateFnsLocalizationExample() {
@@ -29,10 +64,12 @@ function DateFnsLocalizationExample() {
   }, []);
 
   return (
-    <MuiPickersUtilsProvider utils={DateFnsUtils} locale={localeMap[locale]}>
+    <MuiPickersUtilsProvider utils={localeUtilsMap[locale]} locale={localeMap[locale]}>
       <DatePicker
         value={selectedDate}
         onChange={handleDateChange}
+        format={localeFormatMap[locale]}
+        cancelLabel={localeCancelLabelMap[locale]}
         InputProps={{
           endAdornment: (
             <IconButton

--- a/docs/pages/localization/Date-fns.example.jsx
+++ b/docs/pages/localization/Date-fns.example.jsx
@@ -1,8 +1,7 @@
-import format from 'date-fns/format';
 import frLocale from 'date-fns/locale/fr';
 import ruLocale from 'date-fns/locale/ru';
-import enLocale from 'date-fns/locale/en-US';
 import DateFnsUtils from '@date-io/date-fns';
+import enLocale from 'date-fns/locale/en-US';
 import MoreIcon from '@material-ui/icons/MoreVert';
 import React, { useState, useCallback } from 'react';
 import { IconButton, Menu, MenuItem } from '@material-ui/core';
@@ -12,40 +11,6 @@ const localeMap = {
   en: enLocale,
   fr: frLocale,
   ru: ruLocale,
-};
-
-class RuLocalizedUtils extends DateFnsUtils {
-  getCalendarHeaderText(date) {
-    return format(date, 'LLLL', { locale: this.locale });
-  }
-
-  getDatePickerHeaderText(date) {
-    return format(date, 'dd MMMM, EEEE', { locale: this.locale });
-  }
-}
-
-class FrLocalizedUtils extends DateFnsUtils {
-  getDatePickerHeaderText(date) {
-    return format(date, 'd MMM yyyy', { locale: this.locale });
-  }
-}
-
-const localeUtilsMap = {
-  en: DateFnsUtils,
-  fr: FrLocalizedUtils,
-  ru: RuLocalizedUtils,
-};
-
-const localeFormatMap = {
-  en: 'MMMM d, yyyy',
-  fr: 'd MMM yyyy',
-  ru: 'd MMMM yyyy',
-};
-
-const localeCancelLabelMap = {
-  en: 'cancel',
-  fr: 'annuler',
-  ru: 'отмена',
 };
 
 function DateFnsLocalizationExample() {
@@ -64,12 +29,10 @@ function DateFnsLocalizationExample() {
   }, []);
 
   return (
-    <MuiPickersUtilsProvider utils={localeUtilsMap[locale]} locale={localeMap[locale]}>
+    <MuiPickersUtilsProvider utils={DateFnsUtils} locale={localeMap[locale]}>
       <DatePicker
         value={selectedDate}
         onChange={handleDateChange}
-        format={localeFormatMap[locale]}
-        cancelLabel={localeCancelLabelMap[locale]}
         InputProps={{
           endAdornment: (
             <IconButton

--- a/docs/pages/localization/date-fns.mdx
+++ b/docs/pages/localization/date-fns.mdx
@@ -2,6 +2,7 @@ import Ad from '_shared/Ad';
 import Example from '_shared/Example';
 import PageMeta from '_shared/PageMeta';
 import * as DateFnsExample from './Date-fns.example.jsx';
+import * as DateFnsCustomizedExample from './Date-fns-customized.example.jsx';
 
 <PageMeta title="Date-fns localization - @material-ui/pickers" />
 
@@ -11,10 +12,14 @@ When using date-fns, localization is performed by passing a locale object to the
 
 <Ad />
 
-#### Example
-
-To meet various local date standards, you can pass customized values to `DatePicker` props, as well as override default date-fns formatting with classes or `.prototype` object propery. You can read more on this in [Global format customization](https://material-ui-pickers.dev/guides/formats) guide.
+#### Basic example
 
 _Note_: Any picker in the component tree will be re-rendered automatically on locale change.
 
 <Example source={DateFnsExample} />
+
+#### Customization
+
+To meet various local date standards, you can pass customized values to `DatePicker` props, as well as override default date-fns formatting with classes or `.prototype` object propery. You can read more on this in [Global format customization](https://material-ui-pickers.dev/guides/formats) guide.
+
+<Example source={DateFnsCustomizedExample} />

--- a/docs/pages/localization/date-fns.mdx
+++ b/docs/pages/localization/date-fns.mdx
@@ -7,12 +7,14 @@ import * as DateFnsExample from './Date-fns.example.jsx';
 
 ## Localization with date-fns
 
-Date-fns localization simply performs by passing a date-fns locale object to the `MuiPickerUtilsProvider`
+When using date-fns, localization is performed by passing a locale object to the `MuiPickerUtilsProvider` component.
 
 <Ad />
 
 #### Example
 
-_Note_: Any picker in the component tree will be rerendered automatically on locale change
+To meet various local date standards, you can pass customized values to `DatePicker` props, as well as override default date-fns formatting with classes or `.prototype` object propery. You can read more on this in [Global format customization](https://material-ui-pickers.dev/guides/formats) guide.
+
+_Note_: Any picker in the component tree will be re-rendered automatically on locale change.
 
 <Example source={DateFnsExample} />


### PR DESCRIPTION
## Description

I would like to expand date-fns example in the docs with some approaches to customise formatting when date-fns locale object defaults are not appropriate. Since date-fns is very often used for localisation, I believe this is a natural place for more customisation examples. I have also added a link to format customisation guide to this page.

My friend and I were recently bitten by this. She was implementing a picker in tandem with date-fns, and the months were declined incorrectly for that case. Since the issue concerned a particular locale, googling around didn't really help. I then decided to review the docs again and managed to stumble upon Global format customisation guide after quite a bit of digging.

I have also added grammar and style fixes to some of the pages that I had time to  review.

Thank you very much!