### PR TITLE
Fix clock numbers hide in Safari upon selecting hours

### DIFF
--- a/lib/src/views/Clock/Clock.tsx
+++ b/lib/src/views/Clock/Clock.tsx
@@ -38,7 +38,6 @@ export const useStyles = makeStyles(
       width: 260,
       position: 'relative',
       pointerEvents: 'none',
-      zIndex: 1,
     },
     squareMask: {
       width: '100%',


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

This PR closes #1405 <!-- Please refer issue number here, if exists -->

## Description
This PR fixed issue clock numbers hide in Safari upon selecting hours.
Clock div was hiding Clock numbers.