### PR TITLE
Fix copy and paste typo: "desktop" instead of "mobile"

### DIFF
--- a/docs/pages/api/props.tsx
+++ b/docs/pages/api/props.tsx
@@ -76,7 +76,7 @@ const Docs: React.FC<WithRouterProps> = ({ router }) => {
 
           <h4> Desktop Wrapper </h4>
           <Typography gutterBottom>
-            Props available on mobile device with `{componentName}` or with `Desktop{componentName}`
+            Props available on desktop device with `{componentName}` or with `Desktop{componentName}`
           </Typography>
 
           <PropTypesTable disableHeader src="DesktopWrapper" />

--- a/docs/pages/api/props.tsx
+++ b/docs/pages/api/props.tsx
@@ -76,7 +76,7 @@ const Docs: React.FC<WithRouterProps> = ({ router }) => {
 
           <h4> Desktop Wrapper </h4>
           <Typography gutterBottom>
-            Props available on desktop device with `{componentName}` or with `Desktop{componentName}`
+            Props available on desktop device with `{componentName}` or with `Mobile{componentName}`
           </Typography>
 
           <PropTypesTable disableHeader src="DesktopWrapper" />


### PR DESCRIPTION
Thanks for this great package!
See title.
