### PR TITLE
Change the typings of Clock to use a static type as ClassKey

### DIFF
--- a/lib/src/views/Clock/Clock.tsx
+++ b/lib/src/views/Clock/Clock.tsx
@@ -5,7 +5,7 @@ import ClockType, { ClockViewType } from '../../constants/ClockType';
 import { getHours, getMinutes } from '../../_helpers/time-utils';
 import { withStyles, createStyles, WithStyles, Theme } from '@material-ui/core/styles';
 
-export interface ClockProps extends WithStyles<typeof styles> {
+export interface ClockProps extends WithStyles<keyof ReturnType<typeof styles>> {
   type: ClockViewType;
   value: number;
   onChange: (value: number, isFinish?: boolean) => void;


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

This PR closes #1465

## Description
This fixes some compatibility issues with material-ui 4.9.0
It should also be backwards compatible

~~The changes to `docs/prop-types.json` was done automatically by some sort of tooling when i committed... Not sure if the tooling isn't compatible with windows or something.~~
I managed to circumvent the tooling that generates and adds `prop-types.json` to the commit.