### PR TITLE
Better localization 

### DIFF
--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -2,6 +2,7 @@ module.exports = {
   presets: ['next/babel', '@zeit/next-typescript/babel'],
   plugins: [
     '@babel/plugin-proposal-optional-chaining',
+    '@babel/plugin-proposal-nullish-coalescing-operator',
     [
       'babel-plugin-module-resolver',
       {

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,12 +18,8 @@
   },
   "dependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.7.4",
-    "@date-io/date-fns": "^2.0.0",
-    "@date-io/dayjs": "^2.0.1",
     "@date-io/hijri": "^1.3.8",
     "@date-io/jalaali": "^2.0.0",
-    "@date-io/luxon": "^2.0.0",
-    "@date-io/moment": "^2.0.0",
     "@mapbox/rehype-prism": "^0.3.1",
     "@material-ui/core": "^4.5.1",
     "@material-ui/icons": "^3.0.2",
@@ -42,7 +38,7 @@
     "@zeit/next-typescript": "^1.1.1",
     "babel-plugin-module-resolver": "^3.2.0",
     "clsx": "^1.0.2",
-    "date-fns": "^2.0.0-alpha.27",
+    "date-fns": "^2.0.0",
     "dayjs": "^1.8.6",
     "formik": "^1.5.1",
     "fuzzy-search": "^3.0.1",
@@ -75,10 +71,10 @@
     "sinon": "^7.3.2",
     "styled-jsx": "^3.2.4",
     "ts-loader": "^6.0.2",
-    "typescript": "^3.4.4"
+    "typescript": "^3.4.4",
+    "@types/react-redux": "^7.1.7"
   },
   "devDependencies": {
-    "@types/react-redux": "^7.1.7",
     "dotenv": "^7.0.0",
     "eslint-plugin-react": "^7.12.4",
     "fs-extra": "^7.0.1",

--- a/docs/pages/demo/datetime-picker/BasicDateTimePicker.example.jsx
+++ b/docs/pages/demo/datetime-picker/BasicDateTimePicker.example.jsx
@@ -7,7 +7,6 @@ function BasicDateTimePicker() {
   return (
     <Fragment>
       <DateTimePicker
-        mask="____/__/__ __:__"
         label="DateTimePicker"
         variant="outlined"
         value={selectedDate}

--- a/docs/pages/demo/datetime-picker/CustomDateTimePicker.example.jsx
+++ b/docs/pages/demo/datetime-picker/CustomDateTimePicker.example.jsx
@@ -45,6 +45,7 @@ function CustomDateTimePicker(props) {
           moment: 'YYYY/MM/DD hh:mm A',
           dateFns: 'yyyy/MM/dd hh:mm a',
         })}
+        mask="___/__/__ __:__ _M"
       />
 
       <DateTimePicker

--- a/docs/pages/demo/datetime-picker/DateTimePickers.example.jsx
+++ b/docs/pages/demo/datetime-picker/DateTimePickers.example.jsx
@@ -23,14 +23,16 @@ function DateTimePickerDemo(props) {
       />
 
       <DateTimePicker
+        ampm={false}
+        disablePast
         value={selectedDate}
         onChange={handleDateChange}
         onError={console.log}
-        disablePast
         format={props.__willBeReplacedGetFormatString({
           moment: 'YYYY/MM/DD HH:mm',
           dateFns: 'yyyy/MM/dd HH:mm',
         })}
+        mask="___/__/__ __:__"
       />
     </>
   );

--- a/docs/pages/demo/timepicker/BasicTimePicker.example.jsx
+++ b/docs/pages/demo/timepicker/BasicTimePicker.example.jsx
@@ -6,16 +6,10 @@ function BasicTimePicker() {
 
   return (
     <Fragment>
-      <TimePicker
-        ampm
-        mask="__:__ _M"
-        label="12 hours"
-        value={selectedDate}
-        onChange={date => handleDateChange(date)}
-      />
+      <TimePicker label="12 hours" value={selectedDate} onChange={date => handleDateChange(date)} />
 
       <TimePicker
-        mask="__:__"
+        ampm={false} // This is not needed if you are using localization
         label="24 hours"
         value={selectedDate}
         onChange={date => handleDateChange(date)}

--- a/docs/pages/getting-started/installation.mdx
+++ b/docs/pages/getting-started/installation.mdx
@@ -40,9 +40,9 @@ be used at the root of your component tree, or at the highest level you wish the
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 
 // pick a date util library
-import MomentUtils from '@date-io/moment';
-import DateFnsUtils from '@date-io/date-fns';
-import LuxonUtils from '@date-io/luxon';
+import MomentUtils from '@material-ui-pickers/adapter/moment';
+import DateFnsUtils from '@material-ui-pickers/adapter/date-fns';
+import LuxonUtils from '@material-ui-pickers/adapter/luxon';
 
 function App() {
   return (

--- a/docs/pages/getting-started/usage.mdx
+++ b/docs/pages/getting-started/usage.mdx
@@ -17,7 +17,7 @@ import { CODESANDBOX_EXAMPLE_ID } from '_constants';
 
 ```jsx
 import React, { useState } from 'react';
-import DateFnsUtils from '@date-io/date-fns'; // choose your lib
+import DateFnsUtils from '@material-ui-pickers/adapter/date-fns'; // choose your lib
 import {
   DatePicker,
   TimePicker,

--- a/docs/pages/guides/Formats.example.jsx
+++ b/docs/pages/guides/Formats.example.jsx
@@ -1,11 +1,11 @@
 import format from 'date-fns/format';
 import React, { useState } from 'react';
 import frLocale from 'date-fns/locale/fr';
-import DateFnsUtils from '@date-io/date-fns';
+import DateFnsAdapter from '@material-ui/pickers/adapter/date-fns';
 import { DatePicker } from '@material-ui/pickers';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 
-class LocalizedUtils extends DateFnsUtils {
+class LocalizedUtils extends DateFnsAdapter {
   getDatePickerHeaderText(date) {
     return format(date, 'd MMM yyyy', { locale: this.locale });
   }

--- a/docs/pages/localization/Date-fns-customized.example.jsx
+++ b/docs/pages/localization/Date-fns-customized.example.jsx
@@ -2,9 +2,9 @@ import format from 'date-fns/format';
 import frLocale from 'date-fns/locale/fr';
 import ruLocale from 'date-fns/locale/ru';
 import enLocale from 'date-fns/locale/en-US';
-import DateFnsUtils from '@date-io/date-fns';
 import MoreIcon from '@material-ui/icons/MoreVert';
 import React, { useState, useCallback } from 'react';
+import DateFnsAdapter from '@material-ui/pickers/adapter/date-fns';
 import { IconButton, Menu, MenuItem } from '@material-ui/core';
 import { DatePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
 
@@ -14,7 +14,7 @@ const localeMap = {
   ru: ruLocale,
 };
 
-class RuLocalizedUtils extends DateFnsUtils {
+class RuLocalizedUtils extends DateFnsAdapter {
   getCalendarHeaderText(date) {
     return format(date, 'LLLL', { locale: this.locale });
   }
@@ -24,14 +24,14 @@ class RuLocalizedUtils extends DateFnsUtils {
   }
 }
 
-class FrLocalizedUtils extends DateFnsUtils {
+class FrLocalizedUtils extends DateFnsAdapter {
   getDatePickerHeaderText(date) {
     return format(date, 'd MMM yyyy', { locale: this.locale });
   }
 }
 
 const localeUtilsMap = {
-  en: DateFnsUtils,
+  en: DateFnsAdapter,
   fr: FrLocalizedUtils,
   ru: RuLocalizedUtils,
 };

--- a/docs/pages/localization/Date-fns.example.jsx
+++ b/docs/pages/localization/Date-fns.example.jsx
@@ -1,9 +1,9 @@
 import frLocale from 'date-fns/locale/fr';
 import ruLocale from 'date-fns/locale/ru';
-import DateFnsUtils from '@date-io/date-fns';
 import enLocale from 'date-fns/locale/en-US';
 import MoreIcon from '@material-ui/icons/MoreVert';
 import React, { useState, useCallback } from 'react';
+import DateFnsAdapter from '@material-ui/pickers/adapter/date-fns';
 import { IconButton, Menu, MenuItem } from '@material-ui/core';
 import { DatePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
 
@@ -29,7 +29,7 @@ function DateFnsLocalizationExample() {
   }, []);
 
   return (
-    <MuiPickersUtilsProvider utils={DateFnsUtils} locale={localeMap[locale]}>
+    <MuiPickersUtilsProvider utils={DateFnsAdapter} locale={localeMap[locale]}>
       <DatePicker
         value={selectedDate}
         onChange={handleDateChange}

--- a/docs/pages/localization/Moment.example.jsx
+++ b/docs/pages/localization/Moment.example.jsx
@@ -1,7 +1,7 @@
 import moment from 'moment';
-import MomentUtils from '@date-io/moment';
 import MoreIcon from '@material-ui/icons/MoreVert';
 import React, { useState, useCallback } from 'react';
+import MomentAdapter from '@material-ui/pickers/adapter/moment';
 import { IconButton, Menu, MenuItem } from '@material-ui/core';
 import { DatePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
 import 'moment/locale/fr';
@@ -33,7 +33,7 @@ function MomentLocalizationExample() {
   }, []);
 
   return (
-    <MuiPickersUtilsProvider libInstance={moment} utils={MomentUtils} locale={locale}>
+    <MuiPickersUtilsProvider libInstance={moment} utils={MomentAdapter} locale={locale}>
       <DatePicker
         value={selectedDate}
         onChange={date => handleDateChange(date)}

--- a/docs/pages/regression/Regression.tsx
+++ b/docs/pages/regression/Regression.tsx
@@ -41,6 +41,12 @@ function Regression() {
           {...sharedProps}
           format="MM/dd/yyyy"
         />
+        <DesktopDatePicker
+          autoOk
+          id="keyboard-invalid-mask-datepicker"
+          {...sharedProps}
+          mask="__"
+        />
         <MobileDatePicker disabled id="disabled" {...sharedProps} />
         <MobileDatePicker readOnly id="readonly" {...sharedProps} />
       </Grid>

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -812,12 +812,12 @@
         "name": "string"
       }
     },
-    "refuse": {
+    "acceptRegexp": {
       "defaultValue": {
-        "value": "/[^\\d]+/gi"
+        "value": "/\\dap/gi"
       },
-      "description": "Refuse values regexp",
-      "name": "refuse",
+      "description": "Regular expression to detect \"accepted\" symbols",
+      "name": "acceptRegexp",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"
@@ -1349,12 +1349,12 @@
         "name": "string"
       }
     },
-    "refuse": {
+    "acceptRegexp": {
       "defaultValue": {
-        "value": "/[^\\d]+/gi"
+        "value": "/\\dap/gi"
       },
-      "description": "Refuse values regexp",
-      "name": "refuse",
+      "description": "Regular expression to detect \"accepted\" symbols",
+      "name": "acceptRegexp",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"
@@ -1789,12 +1789,12 @@
         "name": "string"
       }
     },
-    "refuse": {
+    "acceptRegexp": {
       "defaultValue": {
-        "value": "/[^\\d]+/gi"
+        "value": "/\\dap/gi"
       },
-      "description": "Refuse values regexp",
-      "name": "refuse",
+      "description": "Regular expression to detect \"accepted\" symbols",
+      "name": "acceptRegexp",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -812,12 +812,12 @@
         "name": "string"
       }
     },
-    "acceptRegexp": {
+    "acceptRegex": {
       "defaultValue": {
         "value": "/\\dap/gi"
       },
       "description": "Regular expression to detect \"accepted\" symbols",
-      "name": "acceptRegexp",
+      "name": "acceptRegex",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"
@@ -1364,12 +1364,12 @@
         "name": "string"
       }
     },
-    "acceptRegexp": {
+    "acceptRegex": {
       "defaultValue": {
         "value": "/\\dap/gi"
       },
       "description": "Regular expression to detect \"accepted\" symbols",
-      "name": "acceptRegexp",
+      "name": "acceptRegex",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"
@@ -1819,12 +1819,12 @@
         "name": "string"
       }
     },
-    "acceptRegexp": {
+    "acceptRegex": {
       "defaultValue": {
         "value": "/\\dap/gi"
       },
       "description": "Regular expression to detect \"accepted\" symbols",
-      "name": "acceptRegexp",
+      "name": "acceptRegex",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -881,6 +881,21 @@
         "name": "boolean"
       }
     },
+    "disableMaskedInput": {
+      "defaultValue": {
+        "value": "false"
+      },
+      "description": "Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format",
+      "name": "disableMaskedInput",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
+        "name": "DateInputProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
     "views": {
       "defaultValue": null,
       "description": "Array of views to show",
@@ -1417,6 +1432,21 @@
       "type": {
         "name": "boolean"
       }
+    },
+    "disableMaskedInput": {
+      "defaultValue": {
+        "value": "false"
+      },
+      "description": "Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format",
+      "name": "disableMaskedInput",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
+        "name": "DateInputProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
     }
   },
   "DateTimePicker": {
@@ -1849,6 +1879,21 @@
       },
       "description": "Do not render open picker button (renders only text field with validation)",
       "name": "hideOpenPickerButton",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
+        "name": "DateInputProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
+    "disableMaskedInput": {
+      "defaultValue": {
+        "value": "false"
+      },
+      "description": "Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format",
+      "name": "disableMaskedInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"

--- a/docs/utils/utilsService.ts
+++ b/docs/utils/utilsService.ts
@@ -1,7 +1,7 @@
-import LuxonUtils from '@date-io/luxon';
-import DayJsUtils from '@date-io/dayjs';
-import MomentUtils from '@date-io/moment';
-import DateFnsUtils from '@date-io/date-fns';
+import LuxonUtils from '@material-ui/pickers/adapter/luxon';
+import DayJsUtils from '@material-ui/pickers/adapter/dayjs';
+import MomentUtils from '@material-ui/pickers/adapter/moment';
+import DateFnsUtils from '@material-ui/pickers/adapter/date-fns';
 
 export const utilsMap = {
   moment: MomentUtils,

--- a/e2e/integration/DatePicker.spec.ts
+++ b/e2e/integration/DatePicker.spec.ts
@@ -2,6 +2,7 @@ const ids = {
   basic: '#basic-datepicker',
   clearable: '#clearable-datepicker',
   maskedKeyboard: '#keyboard-mask-datepicker',
+  notMaskedKeyboard: '#keyboard-invalid-mask-datepicker',
 };
 
 describe('DatePicker', () => {
@@ -11,7 +12,7 @@ describe('DatePicker', () => {
 
   context('Mobile DatePicker', () => {
     it('Should open date picker on 01-01-2018', () => {
-      cy.get(`input${ids.basic}`).should('have.value', '2019/01/01');
+      cy.get(`input${ids.basic}`).should('have.value', '01/01/2019');
 
       cy.get(ids.basic).click({ force: true });
       cy.get('[data-day="21/01/2019"]').click();
@@ -24,8 +25,8 @@ describe('DatePicker', () => {
         .contains('OK')
         .click();
 
-      cy.get(`input${ids.basic}`).should('have.value', '2019/01/21');
-      cy.get(`input${ids.clearable}`).should('have.value', '2019/01/21');
+      cy.get(`input${ids.basic}`).should('have.value', '01/21/2019');
+      cy.get(`input${ids.clearable}`).should('have.value', '01/21/2019');
     });
 
     it('Should change the value to the next month', () => {
@@ -46,7 +47,7 @@ describe('DatePicker', () => {
       cy.get('button')
         .contains('OK')
         .click();
-      cy.get(`input${ids.basic}`).should('have.value', '2019/02/11');
+      cy.get(`input${ids.basic}`).should('have.value', '02/11/2019');
     });
 
     it('Should open mobile keyboard input by clicking on button', () => {
@@ -54,9 +55,9 @@ describe('DatePicker', () => {
       cy.get('[data-mui-test="toggle-mobile-keyboard-view"]').click({ force: true });
 
       cy.get('[data-mui-test="mobile-wrapper-dialog"] [data-mui-test="keyboard-date-input"] input')
-        .should('have.value', '2019/02/11')
+        .should('have.value', '02/11/2019')
         .clear()
-        .type('2019/03/02');
+        .type('03/02/2019');
 
       cy.get('[data-mui-test="picker-toolbar"]').contains('Sat, Mar 2');
       cy.get('[data-mui-test="toggle-mobile-keyboard-view"]').click();
@@ -102,7 +103,7 @@ describe('DatePicker', () => {
         .type('04/01/2019')
         .blur();
 
-      cy.get(`input${ids.basic}`).should('have.value', '2019/04/01');
+      cy.get(`input${ids.basic}`).should('have.value', '04/01/2019');
     });
 
     it('Should open calendar by the keyboard icon', () => {
@@ -119,6 +120,47 @@ describe('DatePicker', () => {
         cy.get(id).click({ force: true });
         cy.get('div[role=dialog]').should('not.be.visible');
       });
+    });
+  });
+
+  context('Input mask', () => {
+    it('Correctly input value to the masked input', () => {
+      cy.get(ids.maskedKeyboard)
+        .clear()
+        .should('have.value', '');
+      cy.get(ids.maskedKeyboard)
+        .type('011')
+        .should('have.value', '01/1_/____');
+
+      cy.get(`${ids.maskedKeyboard}-helper-text`).should('have.text', 'Invalid Date Format');
+
+      cy.get(ids.maskedKeyboard)
+        .type('02019')
+        .should('have.value', '01/10/2019');
+    });
+
+    it('Shows placeholder if no mask provided', () => {
+      cy.get(ids.maskedKeyboard).clear();
+      cy.get(ids.maskedKeyboard)
+        .invoke('attr', 'placeholder')
+        .should('contain', '01/01/2019');
+    });
+
+    it('Allows to enter anything to the not masked input', () => {
+      cy.get(ids.notMaskedKeyboard)
+        .clear()
+        .type('any text')
+        .should('have.value', 'any text');
+
+      cy.get(`${ids.notMaskedKeyboard}-helper-text`).should('have.text', 'Invalid Date Format');
+    });
+
+    it('Correctly parses date string in not masked input', () => {
+      cy.get(ids.notMaskedKeyboard)
+        .clear()
+        .type('01/10/2019');
+
+      cy.get(`${ids.notMaskedKeyboard}-helper-text`).should('not.be.visible');
     });
   });
 });

--- a/e2e/integration/DatePicker.spec.ts
+++ b/e2e/integration/DatePicker.spec.ts
@@ -52,7 +52,9 @@ describe('DatePicker', () => {
 
     it('Should open mobile keyboard input by clicking on button', () => {
       cy.get(ids.clearable).click({ force: true });
-      cy.get('[data-mui-test="toggle-mobile-keyboard-view"]').click({ force: true });
+      cy.get('div[role="dialog"] [data-mui-test="toggle-mobile-keyboard-view"]').click({
+        force: true,
+      });
 
       cy.get('[data-mui-test="mobile-wrapper-dialog"] [data-mui-test="keyboard-date-input"] input')
         .should('have.value', '02/11/2019')

--- a/lib/adapter/date-fns.ts
+++ b/lib/adapter/date-fns.ts
@@ -1,0 +1,3 @@
+export { default } from '@date-io/date-fns';
+
+export const inputMaskFromLocale = () => {};

--- a/lib/adapter/dayjs.ts
+++ b/lib/adapter/dayjs.ts
@@ -1,0 +1,1 @@
+export { default } from '@date-io/dayjs';

--- a/lib/adapter/luxon.ts
+++ b/lib/adapter/luxon.ts
@@ -1,0 +1,1 @@
+export { default } from '@date-io/luxon';

--- a/lib/adapter/moment.ts
+++ b/lib/adapter/moment.ts
@@ -1,0 +1,1 @@
+export { default } from '@date-io/moment';

--- a/lib/babel.config.js
+++ b/lib/babel.config.js
@@ -11,6 +11,7 @@ module.exports = {
     // for IE 11 support
     '@babel/plugin-transform-object-assign',
     '@babel/plugin-proposal-optional-chaining',
+    '@babel/plugin-proposal-nullish-coalescing-operator',
     './remove-prop-types.js',
   ],
   env: {

--- a/lib/package.json
+++ b/lib/package.json
@@ -47,7 +47,7 @@
     "clsx": "^1.0.2",
     "prop-types": "^15.7.2",
     "react-transition-group": "^4.0.0",
-    "rifm": "^0.7.0"
+    "rifm": "^0.10.1"
   },
   "size-limit": [
     {

--- a/lib/package.json
+++ b/lib/package.json
@@ -77,7 +77,6 @@
     "@babel/preset-env": "^7.6.0",
     "@babel/preset-react": "^7.0.0",
     "@cypress/webpack-preprocessor": "^4.1.1",
-    "@date-io/core": "^2.1.0",
     "@material-ui/core": "^4.5.1",
     "@material-ui/icons": "^3.0.2",
     "@material-ui/styles": "^4.8.2",
@@ -119,7 +118,6 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-typescript": "^1.0.0",
     "ts-jest": "^24.0.1",
-    "ts-lib": "0.0.5",
     "typescript": "^3.3.3"
   },
   "jest": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -44,17 +44,15 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.0",
+    "@date-io/date-fns": "^2.1.0",
+    "@date-io/dayjs": "^2.1.0",
+    "@date-io/luxon": "^2.1.0",
+    "@date-io/moment": "^2.1.0",
     "clsx": "^1.0.2",
     "prop-types": "^15.7.2",
     "react-transition-group": "^4.0.0",
     "rifm": "^0.10.1"
   },
-  "size-limit": [
-    {
-      "path": "build/dist/@material-ui/pickers.esm.js",
-      "limit": "30 KB"
-    }
-  ],
   "scripts": {
     "test": "jest",
     "test:date-fns": "UTILS=date-fns yarn test",
@@ -79,10 +77,7 @@
     "@babel/preset-env": "^7.6.0",
     "@babel/preset-react": "^7.0.0",
     "@cypress/webpack-preprocessor": "^4.1.1",
-    "@date-io/core": "^2.0.0",
-    "@date-io/date-fns": "^2.0.0",
-    "@date-io/luxon": "^2.0.0",
-    "@date-io/moment": "^2.0.0",
+    "@date-io/core": "^2.1.0",
     "@material-ui/core": "^4.5.1",
     "@material-ui/icons": "^3.0.2",
     "@material-ui/styles": "^4.8.2",

--- a/lib/src/DatePicker/DatePicker.tsx
+++ b/lib/src/DatePicker/DatePicker.tsx
@@ -32,6 +32,7 @@ const datePickerConfig = {
       ...datePickerDefaultProps,
       views,
       openTo,
+      mask: '__/__/____',
       format: getFormatByViews(views, utils),
     };
   },

--- a/lib/src/DatePicker/DatePickerToolbar.tsx
+++ b/lib/src/DatePicker/DatePickerToolbar.tsx
@@ -44,8 +44,8 @@ export const DatePickerToolbar: React.FC<ToolbarComponentProps> = ({
     // For english localization it is convenient to include weekday into the date "Mon, Jun 1"
     // For other locales using strings like "June 1", without weekday
     return /en/.test(utils.getCurrentLocaleCode())
-      ? utils.format(date, 'normalDate')
-      : utils.format(date, 'shortDate');
+      ? utils.format(date, 'normalDateWithWeekday')
+      : utils.format(date, 'normalDate');
   }, [date, utils, views]);
 
   return (

--- a/lib/src/DatePicker/DatePickerToolbar.tsx
+++ b/lib/src/DatePicker/DatePickerToolbar.tsx
@@ -40,7 +40,12 @@ export const DatePickerToolbar: React.FC<ToolbarComponentProps> = ({
       return utils.format(date, 'month');
     }
 
-    return utils.format(date, 'normalDate');
+    // Little localization hack (Google is doing the same for android native pickers):
+    // For english localization it is convenient to include weekday into the date "Mon, Jun 1"
+    // For other locales using strings like "June 1", without weekday
+    return /en/.test(utils.getCurrentLocaleCode())
+      ? utils.format(date, 'normalDate')
+      : utils.format(date, 'shortDate');
   }, [date, utils, views]);
 
   return (

--- a/lib/src/DateTimePicker/DateTimePicker.tsx
+++ b/lib/src/DateTimePicker/DateTimePicker.tsx
@@ -50,7 +50,7 @@ function useDefaultProps({
     ampmInClock: true,
     orientation,
     showToolbar: true,
-    refuse: ampm ? /[^\dap]+/gi : /[^\d]+/gi,
+    refuse: ampm ? /\dap/gi : /\d/gi,
     format: pick12hOr24hFormat(format, ampm, {
       '12h': utils.formats.keyboardDateTime12h,
       '24h': utils.formats.keyboardDateTime24h,

--- a/lib/src/DateTimePicker/DateTimePicker.tsx
+++ b/lib/src/DateTimePicker/DateTimePicker.tsx
@@ -30,13 +30,15 @@ export type DateTimePickerProps = WithDateInputProps &
   WithViewsProps<'year' | 'date' | 'month' | 'hours' | 'minutes'>;
 
 function useDefaultProps({
-  ampm = false,
+  ampm,
   format,
+  mask,
   orientation = 'portrait',
   openTo = 'date',
   views = ['year', 'date', 'hours', 'minutes'],
 }: DateTimePickerProps) {
   const utils = useUtils();
+  const willUseAmPm = ampm || utils.is12HourCycleInCurrentLocale();
 
   if (orientation !== 'portrait') {
     throw new Error('We are not supporting custom orientation for DateTimePicker yet :(');
@@ -46,12 +48,15 @@ function useDefaultProps({
     ...dateTimePickerDefaultProps,
     openTo,
     views,
+    ampm: willUseAmPm,
     wider: true,
     ampmInClock: true,
     orientation,
     showToolbar: true,
-    refuse: ampm ? /\dap/gi : /\d/gi,
+    acceptRegex: willUseAmPm ? /[\dap]/gi : /\d/gi,
+    mask: mask || willUseAmPm ? '__/__/____ __:__ _M' : '__/__/____ __:__',
     format: pick12hOr24hFormat(format, ampm, {
+      localized: utils.formats.keyboardDateTime,
       '12h': utils.formats.keyboardDateTime12h,
       '24h': utils.formats.keyboardDateTime24h,
     }),

--- a/lib/src/DateTimePicker/DateTimePicker.tsx
+++ b/lib/src/DateTimePicker/DateTimePicker.tsx
@@ -38,7 +38,7 @@ function useDefaultProps({
   views = ['year', 'date', 'hours', 'minutes'],
 }: DateTimePickerProps) {
   const utils = useUtils();
-  const willUseAmPm = ampm || utils.is12HourCycleInCurrentLocale();
+  const willUseAmPm = ampm ?? utils.is12HourCycleInCurrentLocale();
 
   if (orientation !== 'portrait') {
     throw new Error('We are not supporting custom orientation for DateTimePicker yet :(');

--- a/lib/src/TimePicker/TimePicker.tsx
+++ b/lib/src/TimePicker/TimePicker.tsx
@@ -17,19 +17,24 @@ export interface TimePickerProps
     WithDateInputProps {}
 
 function useDefaultProps({
-  ampm = false,
+  ampm,
   format,
+  mask,
   openTo = 'hours',
   views = ['hours', 'minutes'],
 }: TimePickerProps) {
   const utils = useUtils();
+  const willUseAmPm = ampm || utils.is12HourCycleInCurrentLocale();
 
   return {
     ...timePickerDefaultProps,
     views,
     openTo,
-    refuse: ampm ? /\dap/gi : /\d/gi,
+    ampm: willUseAmPm,
+    acceptRegex: willUseAmPm ? /[\dapAP]/gi : /\d/gi,
+    mask: mask || willUseAmPm ? '__:__ _M' : '__:__',
     format: pick12hOr24hFormat(format, ampm, {
+      localized: utils.formats.fullTime,
       '12h': utils.formats.fullTime12h,
       '24h': utils.formats.fullTime24h,
     }),

--- a/lib/src/TimePicker/TimePicker.tsx
+++ b/lib/src/TimePicker/TimePicker.tsx
@@ -28,7 +28,7 @@ function useDefaultProps({
     ...timePickerDefaultProps,
     views,
     openTo,
-    refuse: ampm ? /[^\dap]+/gi : /[^\d]+/gi,
+    refuse: ampm ? /\dap/gi : /\d/gi,
     format: pick12hOr24hFormat(format, ampm, {
       '12h': utils.formats.fullTime12h,
       '24h': utils.formats.fullTime24h,

--- a/lib/src/TimePicker/TimePicker.tsx
+++ b/lib/src/TimePicker/TimePicker.tsx
@@ -24,7 +24,7 @@ function useDefaultProps({
   views = ['hours', 'minutes'],
 }: TimePickerProps) {
   const utils = useUtils();
-  const willUseAmPm = ampm || utils.is12HourCycleInCurrentLocale();
+  const willUseAmPm = ampm ?? utils.is12HourCycleInCurrentLocale();
 
   return {
     ...timePickerDefaultProps,

--- a/lib/src/__tests__/_helpers/text-field-helper.test.tsx
+++ b/lib/src/__tests__/_helpers/text-field-helper.test.tsx
@@ -33,8 +33,10 @@ describe('test-field-helper', () => {
     format                                             | mask                     | expected
     ${utilsToUse.formats.keyboardDate}                 | ${'__.__.____'}          | ${false}
     ${utilsToUse.formats.keyboardDate}                 | ${'__/__/____'}          | ${true}
-    ${utilsToUse.formats.fullTime}                     | ${'__:__ _M'}            | ${true}
-    ${utilsToUse.formats.keyboardDateTime}             | ${'__/__/____ __:__ _M'} | ${true}
+    ${utilsToUse.formats.fullTime}                     | ${'__:__ _M'}            | ${false}
+    ${utilsToUse.formats.keyboardDateTime}             | ${'__/__/____ __:__ _M'} | ${false}
+    ${utilsToUse.formats.keyboardDateTime12h}          | ${'__/__/____ __:__ _M'} | ${true}
+    ${utilsToUse.formats.keyboardDateTime24h}          | ${'__/__/____ __:__'}    | ${true}
     ${{ dateFns: 'MM/dd/yyyy', moment: 'MM/DD/YYYY' }} | ${'__/__/____'}          | ${true}
     ${{ dateFns: 'MMMM yyyy', moment: 'MMMM YYYY' }}   | ${'__/__/____'}          | ${false}
   `(
@@ -47,8 +49,13 @@ describe('test-field-helper', () => {
           ? format.dateFns
           : format.moment;
 
+      if (process.env.UTILS === 'luxon') {
+        return; // luxon has awful formatting strategy we are not supporting mask for luxon's localized formats
+      }
+
       expect(
         checkMaskIsValidForCurrentFormat(mask, formatForCurrentLib, /[\dap]/gi, utilsToUse)
+          .isMaskValid
       ).toBe(expected);
     }
   );

--- a/lib/src/__tests__/_helpers/text-field-helper.test.tsx
+++ b/lib/src/__tests__/_helpers/text-field-helper.test.tsx
@@ -54,7 +54,7 @@ describe('test-field-helper', () => {
       }
 
       expect(
-        checkMaskIsValidForCurrentFormat(mask, formatForCurrentLib, /[\dap]/gi, utilsToUse)
+        checkMaskIsValidForCurrentFormat(mask, '_', formatForCurrentLib, /[\dap]/gi, utilsToUse)
           .isMaskValid
       ).toBe(expected);
     }

--- a/lib/src/__tests__/_helpers/text-field-helper.test.tsx
+++ b/lib/src/__tests__/_helpers/text-field-helper.test.tsx
@@ -7,7 +7,7 @@ import {
   checkMaskIsValidForCurrentFormat,
 } from '../../_helpers/text-field-helper';
 
-const refuse = /[^\d]+/gi;
+const refuse = /[\d]/gi;
 describe('test-field-helper', () => {
   test('maskedDateFormatter', () => {
     const formatterFn = maskedDateFormatter('__/__/____', '_', refuse);
@@ -18,23 +18,25 @@ describe('test-field-helper', () => {
   });
 
   test('pick12hOr24hFormat', () => {
-    expect(pick12hOr24hFormat(undefined, true, { '12h': 'hh:mm a', '24h': 'HH:mm' })).toBe(
-      'hh:mm a'
-    );
-    expect(pick12hOr24hFormat(undefined, undefined, { '12h': 'hh:mm a', '24h': 'HH:mm' })).toBe(
-      'hh:mm a'
-    );
-    expect(pick12hOr24hFormat(undefined, false, { '12h': 'hh:mm a', '24h': 'HH:mm' })).toBe(
-      'HH:mm'
-    );
+    expect(
+      pick12hOr24hFormat(undefined, true, { localized: 'T', '12h': 'hh:mm a', '24h': 'HH:mm' })
+    ).toBe('hh:mm a');
+    expect(
+      pick12hOr24hFormat(undefined, undefined, { localized: 'T', '12h': 'hh:mm a', '24h': 'HH:mm' })
+    ).toBe('T');
+    expect(
+      pick12hOr24hFormat(undefined, false, { localized: 'T', '12h': 'hh:mm a', '24h': 'HH:mm' })
+    ).toBe('HH:mm');
   });
 
   test.each`
-    format                                             | mask            | expected
-    ${utilsToUse.formats.keyboardDate}                 | ${'__/__/____'} | ${true}
-    ${utilsToUse.formats.keyboardDate}                 | ${'__.__.____'} | ${false}
-    ${utilsToUse.formats.fullTime}                     | ${'__:__ _M'}   | ${true}
-    ${{ dateFns: 'MM/dd/yyyy', moment: 'MM/DD/YYYY' }} | ${'__/__/____'} | ${true}
+    format                                             | mask                     | expected
+    ${utilsToUse.formats.keyboardDate}                 | ${'__.__.____'}          | ${false}
+    ${utilsToUse.formats.keyboardDate}                 | ${'__/__/____'}          | ${true}
+    ${utilsToUse.formats.fullTime}                     | ${'__:__ _M'}            | ${true}
+    ${utilsToUse.formats.keyboardDateTime}             | ${'__/__/____ __:__ _M'} | ${true}
+    ${{ dateFns: 'MM/dd/yyyy', moment: 'MM/DD/YYYY' }} | ${'__/__/____'}          | ${true}
+    ${{ dateFns: 'MMMM yyyy', moment: 'MMMM YYYY' }}   | ${'__/__/____'}          | ${false}
   `(
     'checkMaskIsValidFormat returns $expected for mask $mask and format $format',
     ({ format, mask, expected }) => {
@@ -46,7 +48,7 @@ describe('test-field-helper', () => {
           : format.moment;
 
       expect(
-        checkMaskIsValidForCurrentFormat(mask, formatForCurrentLib, /[^\dap]+/gi, utilsToUse)
+        checkMaskIsValidForCurrentFormat(mask, formatForCurrentLib, /[\dap]/gi, utilsToUse)
       ).toBe(expected);
     }
   );

--- a/lib/src/_helpers/text-field-helper.ts
+++ b/lib/src/_helpers/text-field-helper.ts
@@ -128,17 +128,21 @@ export const validate = (
 
 export function pick12hOr24hFormat(
   userFormat: string | undefined,
-  ampm: boolean | undefined = true,
-  formats: { '12h': string; '24h': string }
+  ampm: boolean | undefined,
+  formats: { localized: string; '12h': string; '24h': string }
 ) {
   if (userFormat) {
     return userFormat;
   }
 
+  if (typeof ampm === 'undefined') {
+    return formats.localized;
+  }
+
   return ampm ? formats['12h'] : formats['24h'];
 }
 
-const staticDateForValidation = new Date('2019-11-21T22:00:00.000Z');
+const staticDateForValidation = new Date('2019-11-21T22:30:00.000Z');
 export function checkMaskIsValidForCurrentFormat(
   mask: string,
   format: string,

--- a/lib/src/_helpers/text-field-helper.ts
+++ b/lib/src/_helpers/text-field-helper.ts
@@ -142,17 +142,28 @@ export function pick12hOr24hFormat(
   return ampm ? formats['12h'] : formats['24h'];
 }
 
-const staticDateForValidation = new Date('2019-11-21T22:30:00.000Z');
+const staticDateWith2DigitTokens = new Date('2019-11-21T22:30:00.000');
+export const staticDateWith1DigitTokens = new Date('2019-01-01T09:00:00.000');
 export function checkMaskIsValidForCurrentFormat(
   mask: string,
+  maskChar: string,
   format: string,
   acceptRegex: RegExp,
   utils: IUtils<any>
 ) {
-  const actualFormattedDate = utils.formatByString(utils.date(staticDateForValidation), format);
-  const inferredFormatPattern = actualFormattedDate.replace(acceptRegex, '_');
+  const formattedDateWith1Digit = utils.formatByString(
+    utils.date(staticDateWith1DigitTokens),
+    format
+  );
+  const inferredFormatPatternWith1Digits = formattedDateWith1Digit.replace(acceptRegex, maskChar);
 
-  const isMaskValid = inferredFormatPattern === mask;
+  const inferredFormatPatternWith2Digits = utils
+    .formatByString(utils.date(staticDateWith2DigitTokens), format)
+    .replace(acceptRegex, '_');
+
+  const isMaskValid =
+    inferredFormatPatternWith2Digits === mask && inferredFormatPatternWith1Digits === mask;
+
   // @ts-ignore
   if (!isMaskValid && process.env.NODE_ENV !== 'production') {
     console.warn(
@@ -160,7 +171,7 @@ export function checkMaskIsValidForCurrentFormat(
     );
   }
 
-  return isMaskValid;
+  return { isMaskValid, placeholder: formattedDateWith1Digit };
 }
 
 export const maskedDateFormatter = (mask: string, numberMaskChar: string, accept: RegExp) => (

--- a/lib/src/_shared/KeyboardDateInput.tsx
+++ b/lib/src/_shared/KeyboardDateInput.tsx
@@ -94,8 +94,9 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
   const adornmentPosition = InputAdornmentProps?.position || 'end';
   const inputProps = {
     type: 'tel',
+    disabled,
+    placeholder,
     variant: variant as any,
-    disabled: disabled,
     error: Boolean(validationError),
     helperText: validationError,
     'data-mui-test': 'keyboard-date-input',
@@ -146,12 +147,7 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
       format={rifmFormatter || formatter}
     >
       {({ onChange, value }) => (
-        <TextFieldComponent
-          value={value}
-          onChange={onChange}
-          placeholder={placeholder}
-          {...inputProps}
-        />
+        <TextFieldComponent value={value} onChange={onChange} {...inputProps} />
       )}
     </Rifm>
   );

--- a/lib/src/_shared/KeyboardDateInput.tsx
+++ b/lib/src/_shared/KeyboardDateInput.tsx
@@ -7,6 +7,7 @@ import { useUtils } from './hooks/useUtils';
 import { DateInputProps } from './PureDateInput';
 import { KeyboardIcon } from './icons/KeyboardIcon';
 import {
+  staticDateWith1DigitTokens,
   maskedDateFormatter,
   getDisplayDate,
   checkMaskIsValidForCurrentFormat,
@@ -50,12 +51,16 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
     });
 
   const [innerInputValue, setInnerInputValue] = React.useState<string | null>(getInputValue());
-  const shouldUseMaskedInput = React.useMemo(() => {
-    if (disableMaskedInput) {
-      return false;
+  const { isMaskValid: shouldUseMaskedInput, placeholder } = React.useMemo(() => {
+    // formatting of dates is a quite slow thing, so do not make useless .format calls
+    if (!mask || disableMaskedInput) {
+      return {
+        isMaskValid: false,
+        placeholder: utils.formatByString(staticDateWith1DigitTokens, format),
+      };
     }
 
-    return mask ? checkMaskIsValidForCurrentFormat(mask, format, acceptRegex, utils) : false;
+    return checkMaskIsValidForCurrentFormat(mask, maskChar, format, acceptRegex, utils);
   }, [format, mask]); // eslint-disable-line
 
   // prettier-ignore
@@ -141,7 +146,12 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
       format={rifmFormatter || formatter}
     >
       {({ onChange, value }) => (
-        <TextFieldComponent value={value} onChange={onChange} {...inputProps} />
+        <TextFieldComponent
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          {...inputProps}
+        />
       )}
     </Rifm>
   );

--- a/lib/src/_shared/KeyboardDateInput.tsx
+++ b/lib/src/_shared/KeyboardDateInput.tsx
@@ -7,12 +7,13 @@ import { useUtils } from './hooks/useUtils';
 import { DateInputProps } from './PureDateInput';
 import { KeyboardIcon } from './icons/KeyboardIcon';
 import {
-  makeMaskFromFormat,
   maskedDateFormatter,
   getDisplayDate,
+  checkMaskIsValidForCurrentFormat,
 } from '../_helpers/text-field-helper';
 
 export const KeyboardDateInput: React.FC<DateInputProps> = ({
+  disableMaskedInput,
   rawValue,
   validationError,
   KeyboardButtonProps,
@@ -22,7 +23,7 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
   InputProps,
   mask,
   maskChar = '_',
-  refuse = /[^\d]+/gi,
+  acceptRegexp = /[\d]/gi,
   format,
   disabled,
   rifmFormatter,
@@ -34,9 +35,12 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
   labelFunc,
   hideOpenPickerButton,
   ignoreInvalidInputs,
+  onFocus,
+  onBlur,
   ...other
 }) => {
   const utils = useUtils();
+  const [isFocused, setIsFocused] = React.useState(false);
   const getInputValue = () =>
     getDisplayDate(rawValue, utils, {
       format,
@@ -46,25 +50,32 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
     });
 
   const [innerInputValue, setInnerInputValue] = React.useState<string | null>(getInputValue());
+  const shouldUseMaskedInput = React.useMemo(() => {
+    if (disableMaskedInput) {
+      return false;
+    }
 
-  const inputMask = mask || makeMaskFromFormat(format, maskChar);
+    return mask ? checkMaskIsValidForCurrentFormat(mask, format, acceptRegexp, utils) : false;
+  }, [format, mask]); // eslint-disable-line
+
   // prettier-ignore
   const formatter = React.useMemo(
-    () => maskedDateFormatter(inputMask, maskChar, refuse),
-    [inputMask, maskChar, refuse]
+    () => shouldUseMaskedInput && mask
+       ? maskedDateFormatter(mask, maskChar, acceptRegexp)
+       : (st: string) => st,
+    [shouldUseMaskedInput, mask, maskChar, acceptRegexp]
   );
 
   React.useEffect(() => {
-    if (rawValue === null || utils.isValid(rawValue)) {
+    // If not using mask don't update input on state change when focused to avoid such weird thing:
+    // When parsing format "yyyy" with input value "2" value parsed and input value updating to "0002"
+    if ((rawValue === null || utils.isValid(rawValue)) && !isFocused) {
       setInnerInputValue(getInputValue());
     }
   }, [rawValue]); // eslint-disable-line
 
-  const position =
-    InputAdornmentProps && InputAdornmentProps.position ? InputAdornmentProps.position : 'end';
-
   const handleChange = (text: string) => {
-    const finalString = text === '' || text === inputMask ? null : text;
+    const finalString = text === '' || text === mask ? null : text;
     setInnerInputValue(finalString);
 
     const date = finalString === null ? null : utils.parse(finalString, format);
@@ -75,42 +86,62 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
     onChange(date, finalString || undefined);
   };
 
+  const adornmentPosition = InputAdornmentProps?.position || 'end';
+  const inputProps = {
+    type: 'tel',
+    variant: variant as any,
+    disabled: disabled,
+    error: Boolean(validationError),
+    helperText: validationError,
+    'data-mui-test': 'keyboard-date-input',
+    ...other,
+    InputProps: {
+      ...InputProps,
+      [`${adornmentPosition}Adornment`]: hideOpenPickerButton ? (
+        undefined
+      ) : (
+        <InputAdornment position={adornmentPosition} {...InputAdornmentProps}>
+          <IconButton
+            data-mui-test="open-picker-from-keyboard"
+            disabled={disabled}
+            {...KeyboardButtonProps}
+            onClick={onOpen}
+          >
+            {keyboardIcon}
+          </IconButton>
+        </InputAdornment>
+      ),
+    },
+  };
+
+  if (!shouldUseMaskedInput) {
+    return (
+      <TextFieldComponent
+        value={innerInputValue || ''}
+        onChange={e => handleChange(e.currentTarget.value)}
+        {...inputProps}
+        onFocus={e => {
+          setIsFocused(true);
+          onFocus && onFocus(e);
+        }}
+        onBlur={e => {
+          setIsFocused(false);
+          onBlur && onBlur(e);
+        }}
+      />
+    );
+  }
+
   return (
     <Rifm
-      key={inputMask}
+      key={mask}
       value={innerInputValue || ''}
       onChange={handleChange}
-      refuse={refuse}
+      accept={acceptRegexp}
       format={rifmFormatter || formatter}
     >
       {({ onChange, value }) => (
-        <TextFieldComponent
-          variant={variant as any}
-          disabled={disabled}
-          error={Boolean(validationError)}
-          helperText={validationError}
-          data-mui-test="keyboard-date-input"
-          {...other}
-          value={value}
-          onChange={onChange}
-          InputProps={{
-            ...InputProps,
-            [`${position}Adornment`]: hideOpenPickerButton ? (
-              undefined
-            ) : (
-              <InputAdornment position={position} {...InputAdornmentProps}>
-                <IconButton
-                  data-mui-test="open-picker-from-keyboard"
-                  disabled={disabled}
-                  {...KeyboardButtonProps}
-                  onClick={onOpen}
-                >
-                  {keyboardIcon}
-                </IconButton>
-              </InputAdornment>
-            ),
-          }}
-        />
+        <TextFieldComponent value={value} onChange={onChange} {...inputProps} />
       )}
     </Rifm>
   );

--- a/lib/src/_shared/KeyboardDateInput.tsx
+++ b/lib/src/_shared/KeyboardDateInput.tsx
@@ -23,7 +23,7 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
   InputProps,
   mask,
   maskChar = '_',
-  acceptRegexp = /[\d]/gi,
+  acceptRegex = /[\d]/gi,
   format,
   disabled,
   rifmFormatter,
@@ -55,15 +55,15 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
       return false;
     }
 
-    return mask ? checkMaskIsValidForCurrentFormat(mask, format, acceptRegexp, utils) : false;
+    return mask ? checkMaskIsValidForCurrentFormat(mask, format, acceptRegex, utils) : false;
   }, [format, mask]); // eslint-disable-line
 
   // prettier-ignore
   const formatter = React.useMemo(
     () => shouldUseMaskedInput && mask
-       ? maskedDateFormatter(mask, maskChar, acceptRegexp)
+       ? maskedDateFormatter(mask, maskChar, acceptRegex)
        : (st: string) => st,
-    [shouldUseMaskedInput, mask, maskChar, acceptRegexp]
+    [shouldUseMaskedInput, mask, maskChar, acceptRegex]
   );
 
   React.useEffect(() => {
@@ -137,7 +137,7 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
       key={mask}
       value={innerInputValue || ''}
       onChange={handleChange}
-      accept={acceptRegexp}
+      accept={acceptRegex}
       format={rifmFormatter || formatter}
     >
       {({ onChange, value }) => (

--- a/lib/src/_shared/PureDateInput.tsx
+++ b/lib/src/_shared/PureDateInput.tsx
@@ -54,7 +54,7 @@ export interface DateInputProps
    *Regular expression to detect "accepted" symbols
    * @default /\dap/gi
    */
-  acceptRegexp?: RegExp;
+  acceptRegex?: RegExp;
   /**
    * Props to pass to keyboard input adornment
    * @type {Partial<InputAdornmentProps>}
@@ -87,7 +87,7 @@ export const PureDateInput: React.FC<DateInputProps> = ({
   onChange,
   format,
   rifmFormatter,
-  acceptRegexp: refuse,
+  acceptRegex: refuse,
   mask,
   rawValue,
   maskChar,

--- a/lib/src/_shared/PureDateInput.tsx
+++ b/lib/src/_shared/PureDateInput.tsx
@@ -51,10 +51,10 @@ export interface DateInputProps
    */
   maskChar?: string;
   /**
-   * Refuse values regexp
-   * @default /[^\d]+/gi
+   *Regular expression to detect "accepted" symbols
+   * @default /\dap/gi
    */
-  refuse?: RegExp;
+  acceptRegexp?: RegExp;
   /**
    * Props to pass to keyboard input adornment
    * @type {Partial<InputAdornmentProps>}
@@ -72,6 +72,11 @@ export interface DateInputProps
    * @default false
    */
   hideOpenPickerButton?: boolean;
+  /**
+   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format
+   * @default false
+   */
+  disableMaskedInput?: boolean;
   // ?? TODO when it will be possible to display "empty" date in datepicker use it instead of ignoring invalid inputs
   ignoreInvalidInputs?: boolean;
 }
@@ -82,7 +87,7 @@ export const PureDateInput: React.FC<DateInputProps> = ({
   onChange,
   format,
   rifmFormatter,
-  refuse,
+  acceptRegexp: refuse,
   mask,
   rawValue,
   maskChar,

--- a/lib/src/constants/prop-types.ts
+++ b/lib/src/constants/prop-types.ts
@@ -17,7 +17,6 @@ export const DomainPropTypes = { date, datePickerView };
 
 /* eslint-disable @typescript-eslint/no-object-literal-type-assertion */
 export const timePickerDefaultProps = {
-  ampm: false,
   invalidDateMessage: 'Invalid Time Format',
 } as BaseClockViewProps;
 

--- a/package.json
+++ b/package.json
@@ -30,9 +30,13 @@
     "url": "git+https://github.com/mui-org/material-ui-pickers.git"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
     "@babel/runtime": "^7.7.5",
+    "@cypress/webpack-preprocessor": "^4.1.0",
+    "@percy/cypress": "^1.0.9",
     "@typescript-eslint/eslint-plugin": "^1.6.0",
     "@typescript-eslint/parser": "^1.6.0",
+    "cypress": "^3.2.0",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-pretty-imports": "^1.0.2",
@@ -41,9 +45,6 @@
     "husky": "^1.1.2",
     "lint-staged": "^7.3.0",
     "prettier": "^1.14.3",
-    "@cypress/webpack-preprocessor": "^4.1.0",
-    "@percy/cypress": "^1.0.9",
-    "cypress": "^3.2.0",
     "wait-on": "^3.2.0"
   },
   "husky": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10108,12 +10108,10 @@ reusify@^1.0.0:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rifm@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/rifm/-/rifm-0.7.0.tgz#debe951a9c83549ca6b33e5919f716044c2230be"
-  integrity sha512-DSOJTWHD67860I5ojetXdEQRIBvF6YcpNe53j0vn1vp9EUb9N80EiZTxgP+FkDKorWC8PZw052kTF4C1GOivCQ==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
+rifm@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/rifm/-/rifm-0.10.1.tgz#2db1b2e006e1fd3540caffd012bdbcd96e5d6e5a"
+  integrity sha512-Y1kCEFNCEkqRlmjHhQ91fVXfv8VxeXW1UBIbaCYqFdMWPF/8Lf10/1dUdtuAuZ44Krdj/n1eYIt/20gs2HZoKA==
 
 rimraf@2.6.3:
   version "2.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,6 +246,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
   integrity sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==
 
+"@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz#9ea293be19babc0f52ff8ca88b34c3611b208670"
+  integrity sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
+
 "@babel/helper-regex@^7.0.0", "@babel/helper-regex@^7.4.4":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.5.5.tgz#0aa6824f7100a2e0e89c1527c23936c152cab351"
@@ -413,6 +418,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-json-strings" "^7.2.0"
 
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz#e4572253fdeed65cddeecfdab3f928afeb2fd5d2"
+  integrity sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+
 "@babel/plugin-proposal-object-rest-spread@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz#9a17b547f64d0676b6c9cecd4edf74a82ab85e7e"
@@ -511,6 +524,13 @@
   integrity sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
+  integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
 
 "@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.2.0":
   version "7.2.0"
@@ -1259,43 +1279,24 @@
   resolved "https://registry.yarnpkg.com/@date-io/core/-/core-1.3.13.tgz#90c71da493f20204b7a972929cc5c482d078b3fa"
   integrity sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA==
 
-"@date-io/core@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.0.0.tgz#3a8685b8f5ea25513327e1273a673b5477573ce9"
-  integrity sha512-Zam4FfQrRhGobLyjwM4qL9yoAZ66+jGHjXWf7ZrqRqeP/mrrVEAG2td/xHuUzCKz4xN3NzGcrd3r42p4n6UgXA==
+"@date-io/core@^2.1.0", "@date-io/core@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.2.0.tgz#cb351cefa3544460f183ebf26b52f3b5781c28fa"
+  integrity sha512-QM0ESKqAtuz8kNz53XYJFLZtceVp1V1cbhqdIDMveB0wSfDfBk8m5iT0GkHv5RIs+p6PXVd3zkeqz/qD4UzdPw==
 
-"@date-io/core@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.1.0.tgz#7ce2bec7a93c4525e7c016eaabf3e571dee8029f"
-  integrity sha512-akcCcYmHXkRp9uSqvNGvnMJbbcoD3Wo+NfswETfzXPkVviIFz2TVN8g5D/kwM5ZkiEo4t7nyBkpuYtNzv1WVdg==
-
-"@date-io/date-fns@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-2.0.1.tgz#191614dc6241c88e4a782acbd259420f3798a979"
-  integrity sha512-wy3CWuV0dvrjm45ncO6duu4ZSOMxZpajFbEoj0X3DyNEYxjAdbv27waZYtJ2PwL85XZd9i/VaJQnh3GU7ZvP6g==
+"@date-io/date-fns@^2.0.0", "@date-io/date-fns@^2.1.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-2.2.0.tgz#366a3fbeddf9bfbfe6286d44bdb0e5f8c1e12545"
+  integrity sha512-69+fw/RfOT8PwJrfR6xMzn0gewkFOBEgO/j4o2xiI/u4jw4mX26H5o8W43arzLTmIHQ8bg64sjci0M00QOpWAg==
   dependencies:
-    "@date-io/core" "^2.0.0"
+    "@date-io/core" "^2.2.0"
 
-"@date-io/date-fns@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-2.1.0.tgz#178bdd8405b8540d3f68f671a54a539d72835338"
-  integrity sha512-5ouqxSze5O0+45TPdfUTZKzKic7LtvxVD9IXXBmzyFUC6x++tQpDYWlDg3CX5CFa3ZbX9uoqOGekKCwn4PC40w==
+"@date-io/dayjs@^2.0.1", "@date-io/dayjs@^2.1.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@date-io/dayjs/-/dayjs-2.2.0.tgz#236cbd1d49da3e871503adaa9ad1ebcd6628c8f6"
+  integrity sha512-U/jlTqb4+AoiPRl1Rs9/+kmorBQ5sEsAam5ovs1cKajh6OpxZ4LteD3E5fB/dzEWIxJAwVBwdnA4vLf1zsAbgg==
   dependencies:
-    "@date-io/core" "^2.1.0"
-
-"@date-io/dayjs@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@date-io/dayjs/-/dayjs-2.0.1.tgz#f9df69cc1d21f29416854ccf93f68287ee8e7e59"
-  integrity sha512-itxz7JphcGOwAtcPHaa4PkK6yv5W3Ik044ihMytQxHdSNuLGyHUksrBEEuhFXGFqcMXyYf7wVBEFxuZqz8bzig==
-  dependencies:
-    "@date-io/core" "^2.0.0"
-
-"@date-io/dayjs@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@date-io/dayjs/-/dayjs-2.1.0.tgz#8af516f63426038079a4700aa136d1c4522f2375"
-  integrity sha512-GBOP5hyLjuA6el6sjXulScZPp/8vR63z2UGNGDSFEEsExiHzKZMjxc1ETfIvHw8SdbrIqpBQG0IPnBZGpQq5Cg==
-  dependencies:
-    "@date-io/core" "^2.1.0"
+    "@date-io/core" "^2.2.0"
 
 "@date-io/hijri@^1.3.8":
   version "1.3.13"
@@ -1305,25 +1306,18 @@
     "@date-io/moment" "^1.3.13"
 
 "@date-io/jalaali@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@date-io/jalaali/-/jalaali-2.0.1.tgz#e8d6d90609a629603576864b94349e21c5340c75"
-  integrity sha512-b8ppE9UsdTuTbzAEEBlDyyAgbNNp507zT94OBcNKl7zFQcQ7V11uIyaNa0kq1u3RgitI9zcLe1+mAoO4huUG0g==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@date-io/jalaali/-/jalaali-2.2.0.tgz#5a6b00fdb3e7e969725764549931bc2ff5cd4a19"
+  integrity sha512-CTS6ERElHhuyhLqG8iuRLWqbXsRQknLpgCcxg2YeqP/PgVbZC4EDsO5bc8FLIGQbOeEPKGj8SC2q2yE4RyZzdA==
   dependencies:
-    "@date-io/moment" "^2.0.1"
+    "@date-io/moment" "^2.2.0"
 
-"@date-io/luxon@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@date-io/luxon/-/luxon-2.0.1.tgz#dedcd8e811ed1e334656148a02b372eb7d0d58b1"
-  integrity sha512-CPu1WA/KYyU6ddR2DoFJPWjlnQt1UsXU3vcw8Q0uxmQMQZcChj/f+0cYQ+DGPsgKBQ8IVlZt1EGWa4W/GkJ9MQ==
+"@date-io/luxon@^2.0.0", "@date-io/luxon@^2.1.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@date-io/luxon/-/luxon-2.2.0.tgz#91ed2ff6e88c9090ab50ff6ca4ecc2efc5a48c05"
+  integrity sha512-mRLEm08a2uvsxze9PwMyi7RAiQJF/UHjJXRHbc5FnuYSBHsKKzoyicafCntJxvGX0tKePdzDnusXrukW3JrBdA==
   dependencies:
-    "@date-io/core" "^2.0.0"
-
-"@date-io/luxon@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@date-io/luxon/-/luxon-2.1.0.tgz#2de6216883a786ed002ae7ced8df03e0009299a8"
-  integrity sha512-86IJHQmpvEWZNnFGA/oG+Dp3q5FPe7jho5RzLSBSKaPtv9U6Ur6azjdKRzqKAI/PJlXaHq9jKULE/XgviT+JJw==
-  dependencies:
-    "@date-io/core" "^2.1.0"
+    "@date-io/core" "^2.2.0"
 
 "@date-io/moment@^1.3.13":
   version "1.3.13"
@@ -1332,19 +1326,12 @@
   dependencies:
     "@date-io/core" "^1.3.13"
 
-"@date-io/moment@^2.0.0", "@date-io/moment@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-2.0.1.tgz#5f89e23f22299a41ba94890b3895f1684517e541"
-  integrity sha512-smoY6hyzvexFPQKijhxeNy7w5PRVSiOnMeu01KEvlRs8oUeHGsz/D18N4XpboGhlYYMDujqJaxf0eGzJmFIY7Q==
+"@date-io/moment@^2.0.0", "@date-io/moment@^2.1.0", "@date-io/moment@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-2.2.0.tgz#e9ed751c92d29e211ef729de67e67619720313f1"
+  integrity sha512-EFEwNBMCrUhYVic31dzKZLsftgu7DlKZ90yTDFrPnwt4Mk9PV1FcT4VYsmyp+F6V0LP9+X7zHSktxDJE9Jq9Qg==
   dependencies:
-    "@date-io/core" "^2.0.0"
-
-"@date-io/moment@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-2.1.0.tgz#cc6aeff8fe5250e2423e748bb279b565f7fb2c8a"
-  integrity sha512-/iW3voYQ4ZQLTNqpY2pLzb7/nhNLjvF+J9TApEFU9M+ci1YcgPsib1sWBzMdbta5O1pB2d8EElfvXRq2vWQsww==
-  dependencies:
-    "@date-io/core" "^2.1.0"
+    "@date-io/core" "^2.2.0"
 
 "@emotion/hash@^0.7.4":
   version "0.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1264,6 +1264,11 @@
   resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.0.0.tgz#3a8685b8f5ea25513327e1273a673b5477573ce9"
   integrity sha512-Zam4FfQrRhGobLyjwM4qL9yoAZ66+jGHjXWf7ZrqRqeP/mrrVEAG2td/xHuUzCKz4xN3NzGcrd3r42p4n6UgXA==
 
+"@date-io/core@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.1.0.tgz#7ce2bec7a93c4525e7c016eaabf3e571dee8029f"
+  integrity sha512-akcCcYmHXkRp9uSqvNGvnMJbbcoD3Wo+NfswETfzXPkVviIFz2TVN8g5D/kwM5ZkiEo4t7nyBkpuYtNzv1WVdg==
+
 "@date-io/date-fns@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-2.0.1.tgz#191614dc6241c88e4a782acbd259420f3798a979"
@@ -1271,12 +1276,26 @@
   dependencies:
     "@date-io/core" "^2.0.0"
 
+"@date-io/date-fns@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-2.1.0.tgz#178bdd8405b8540d3f68f671a54a539d72835338"
+  integrity sha512-5ouqxSze5O0+45TPdfUTZKzKic7LtvxVD9IXXBmzyFUC6x++tQpDYWlDg3CX5CFa3ZbX9uoqOGekKCwn4PC40w==
+  dependencies:
+    "@date-io/core" "^2.1.0"
+
 "@date-io/dayjs@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@date-io/dayjs/-/dayjs-2.0.1.tgz#f9df69cc1d21f29416854ccf93f68287ee8e7e59"
   integrity sha512-itxz7JphcGOwAtcPHaa4PkK6yv5W3Ik044ihMytQxHdSNuLGyHUksrBEEuhFXGFqcMXyYf7wVBEFxuZqz8bzig==
   dependencies:
     "@date-io/core" "^2.0.0"
+
+"@date-io/dayjs@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@date-io/dayjs/-/dayjs-2.1.0.tgz#8af516f63426038079a4700aa136d1c4522f2375"
+  integrity sha512-GBOP5hyLjuA6el6sjXulScZPp/8vR63z2UGNGDSFEEsExiHzKZMjxc1ETfIvHw8SdbrIqpBQG0IPnBZGpQq5Cg==
+  dependencies:
+    "@date-io/core" "^2.1.0"
 
 "@date-io/hijri@^1.3.8":
   version "1.3.13"
@@ -1299,6 +1318,13 @@
   dependencies:
     "@date-io/core" "^2.0.0"
 
+"@date-io/luxon@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@date-io/luxon/-/luxon-2.1.0.tgz#2de6216883a786ed002ae7ced8df03e0009299a8"
+  integrity sha512-86IJHQmpvEWZNnFGA/oG+Dp3q5FPe7jho5RzLSBSKaPtv9U6Ur6azjdKRzqKAI/PJlXaHq9jKULE/XgviT+JJw==
+  dependencies:
+    "@date-io/core" "^2.1.0"
+
 "@date-io/moment@^1.3.13":
   version "1.3.13"
   resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-1.3.13.tgz#56c2772bc4f6675fc6970257e6033e7a7c2960f0"
@@ -1312,6 +1338,13 @@
   integrity sha512-smoY6hyzvexFPQKijhxeNy7w5PRVSiOnMeu01KEvlRs8oUeHGsz/D18N4XpboGhlYYMDujqJaxf0eGzJmFIY7Q==
   dependencies:
     "@date-io/core" "^2.0.0"
+
+"@date-io/moment@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-2.1.0.tgz#cc6aeff8fe5250e2423e748bb279b565f7fb2c8a"
+  integrity sha512-/iW3voYQ4ZQLTNqpY2pLzb7/nhNLjvF+J9TApEFU9M+ci1YcgPsib1sWBzMdbta5O1pB2d8EElfvXRq2vWQsww==
+  dependencies:
+    "@date-io/core" "^2.1.0"
 
 "@emotion/hash@^0.7.4":
   version "0.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,19 +1279,19 @@
   resolved "https://registry.yarnpkg.com/@date-io/core/-/core-1.3.13.tgz#90c71da493f20204b7a972929cc5c482d078b3fa"
   integrity sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA==
 
-"@date-io/core@^2.1.0", "@date-io/core@^2.2.0":
+"@date-io/core@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.2.0.tgz#cb351cefa3544460f183ebf26b52f3b5781c28fa"
   integrity sha512-QM0ESKqAtuz8kNz53XYJFLZtceVp1V1cbhqdIDMveB0wSfDfBk8m5iT0GkHv5RIs+p6PXVd3zkeqz/qD4UzdPw==
 
-"@date-io/date-fns@^2.0.0", "@date-io/date-fns@^2.1.0":
+"@date-io/date-fns@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-2.2.0.tgz#366a3fbeddf9bfbfe6286d44bdb0e5f8c1e12545"
   integrity sha512-69+fw/RfOT8PwJrfR6xMzn0gewkFOBEgO/j4o2xiI/u4jw4mX26H5o8W43arzLTmIHQ8bg64sjci0M00QOpWAg==
   dependencies:
     "@date-io/core" "^2.2.0"
 
-"@date-io/dayjs@^2.0.1", "@date-io/dayjs@^2.1.0":
+"@date-io/dayjs@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@date-io/dayjs/-/dayjs-2.2.0.tgz#236cbd1d49da3e871503adaa9ad1ebcd6628c8f6"
   integrity sha512-U/jlTqb4+AoiPRl1Rs9/+kmorBQ5sEsAam5ovs1cKajh6OpxZ4LteD3E5fB/dzEWIxJAwVBwdnA4vLf1zsAbgg==
@@ -1312,7 +1312,7 @@
   dependencies:
     "@date-io/moment" "^2.2.0"
 
-"@date-io/luxon@^2.0.0", "@date-io/luxon@^2.1.0":
+"@date-io/luxon@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@date-io/luxon/-/luxon-2.2.0.tgz#91ed2ff6e88c9090ab50ff6ca4ecc2efc5a48c05"
   integrity sha512-mRLEm08a2uvsxze9PwMyi7RAiQJF/UHjJXRHbc5FnuYSBHsKKzoyicafCntJxvGX0tKePdzDnusXrukW3JrBdA==
@@ -1326,7 +1326,7 @@
   dependencies:
     "@date-io/core" "^1.3.13"
 
-"@date-io/moment@^2.0.0", "@date-io/moment@^2.1.0", "@date-io/moment@^2.2.0":
+"@date-io/moment@^2.1.0", "@date-io/moment@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-2.2.0.tgz#e9ed751c92d29e211ef729de67e67619720313f1"
   integrity sha512-EFEwNBMCrUhYVic31dzKZLsftgu7DlKZ90yTDFrPnwt4Mk9PV1FcT4VYsmyp+F6V0LP9+X7zHSktxDJE9Jq9Qg==
@@ -4242,6 +4242,11 @@ date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+
+date-fns@^2.0.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.9.0.tgz#d0b175a5c37ed5f17b97e2272bbc1fa5aec677d2"
+  integrity sha512-khbFLu/MlzLjEzy9Gh8oY1hNt/Dvxw3J6Rbc28cVoYWQaC1S3YI4xwkF9ZWcjDLscbZlY9hISMr66RFzZagLsA==
 
 date-fns@^2.0.0-alpha.27:
   version "2.8.1"
@@ -11361,11 +11366,6 @@ ts-jest@^24.0.1:
     resolve "1.x"
     semver "^5.5"
     yargs-parser "10.x"
-
-ts-lib@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/ts-lib/-/ts-lib-0.0.5.tgz#7f319885478de67f575a3b890a3f30fc6159352a"
-  integrity sha1-fzGYhUeN5n9XWjuJCj8w/GFZNSo=
 
 ts-loader@^6.0.2:
   version "6.2.1"


### PR DESCRIPTION
## Improve localization 

### User facing changes
1. We are now hosting `date-io` adapter by ourselves. So you need to import it from `@material-ui/pickers/adapter/date-fns' instead of right from `@date-io/date-fns` 
2. No more need in `ampm` prop. Actually **finally** resolving #723 locale settings will be inferred from the locale setup. 
3. No more weird autogeneration, which was useless with localized tokens and was intended to be working only for hardcoded tokens, so it was a reason of issues like #1478 

So now the user will need to manually set the mask for different locales. If provided mask is not valid for the current locale -> mask will not be rendered and we are falling back to the unparsed input

![Screen Recording 2020-01-31 at 18 18 42](https://user-images.githubusercontent.com/16926049/73555496-67f1d680-4456-11ea-88cb-334ec98df7dc.gif)

4. Introduce `disableMaskedInput ` prop just to disable masking at all (force the same behavior ^)
5. Better localization for datepicker and datetimepicker mobile toolbar labels, right now they are still not so brilliant localized but will satisfy most of the locales. 


### TODO
Figure out the input mask generation for other locales. I propose to reexport another function from each adapter file, like 

```jsx
import { getMaskForLocale } from '@material-ui/pickers/adapter/date-fns'

<DatePicker
  mask={getMaskForLocale("en-US")} 
/> 
```

This function will just hardcode the mask for each format token for each locale. I do think that idea to generate a mask from the format will not work us as well, so we just need to manually feel mask for each locale. 

Here is a list of formats for different libs: 
<details>
  <summary>Moment</summary>
  
  ```javascript
const localesMap = {
  af: "DD/MM/YYYY",
  "ar-dz": "DD/MM/YYYY",
  "ar-kw": "DD/MM/YYYY",
  "ar-ly": "D/\u200FM/\u200FYYYY",
  "ar-ma": "DD/MM/YYYY",
  "ar-sa": "DD/MM/YYYY",
  "ar-tn": "DD/MM/YYYY",
  ar: "D/\u200FM/\u200FYYYY",
  az: "DD.MM.YYYY",
  be: "DD.MM.YYYY",
  bg: "D.MM.YYYY",
  bm: "DD/MM/YYYY",
  bn: "DD/MM/YYYY",
  bo: "DD/MM/YYYY",
  br: "DD/MM/YYYY",
  bs: "DD.MM.YYYY",
  ca: "DD/MM/YYYY",
  cs: "DD.MM.YYYY",
  cv: "DD-MM-YYYY",
  cy: "DD/MM/YYYY",
  da: "DD.MM.YYYY",
  "de-at": "DD.MM.YYYY",
  "de-ch": "DD.MM.YYYY",
  de: "DD.MM.YYYY",
  dv: "D/M/YYYY",
  el: "DD/MM/YYYY",
  "en-SG": "DD/MM/YYYY",
  "en-au": "DD/MM/YYYY",
  "en-ca": "YYYY-MM-DD",
  "en-gb": "DD/MM/YYYY",
  "en-ie": "DD/MM/YYYY",
  "en-il": "DD/MM/YYYY",
  "en-nz": "DD/MM/YYYY",
  eo: "YYYY-MM-DD",
  "es-do": "DD/MM/YYYY",
  "es-us": "MM/DD/YYYY",
  es: "DD/MM/YYYY",
  et: "DD.MM.YYYY",
  eu: "YYYY-MM-DD",
  fa: "DD/MM/YYYY",
  fi: "DD.MM.YYYY",
  fo: "DD/MM/YYYY",
  "fr-ca": "YYYY-MM-DD",
  "fr-ch": "DD.MM.YYYY",
  fr: "DD/MM/YYYY",
  fy: "DD-MM-YYYY",
  ga: "DD/MM/YYYY",
  gd: "DD/MM/YYYY",
  gl: "DD/MM/YYYY",
  "gom-latn": "DD-MM-YYYY",
  gu: "DD/MM/YYYY",
  he: "DD/MM/YYYY",
  hi: "DD/MM/YYYY",
  hr: "DD.MM.YYYY",
  hu: "YYYY.MM.DD.",
  "hy-am": "DD.MM.YYYY",
  id: "DD/MM/YYYY",
  is: "DD.MM.YYYY",
  "it-ch": "DD.MM.YYYY",
  it: "DD/MM/YYYY",
  ja: "YYYY/MM/DD",
  jv: "DD/MM/YYYY",
  ka: "DD/MM/YYYY",
  kk: "DD.MM.YYYY",
  km: "DD/MM/YYYY",
  kn: "DD/MM/YYYY",
  ko: "YYYY.MM.DD.",
  ku: "DD/MM/YYYY",
  ky: "DD.MM.YYYY",
  lb: "DD.MM.YYYY",
  lo: "DD/MM/YYYY",
  lt: "YYYY-MM-DD",
  lv: "DD.MM.YYYY.",
  me: "DD.MM.YYYY",
  mi: "DD/MM/YYYY",
  mk: "D.MM.YYYY",
  ml: "DD/MM/YYYY",
  mn: "YYYY-MM-DD",
  mr: "DD/MM/YYYY",
  "ms-my": "DD/MM/YYYY",
  ms: "DD/MM/YYYY",
  mt: "DD/MM/YYYY",
  my: "DD/MM/YYYY",
  nb: "DD.MM.YYYY",
  ne: "DD/MM/YYYY",
  "nl-be": "DD/MM/YYYY",
  nl: "DD-MM-YYYY",
  nn: "DD.MM.YYYY",
  "pa-in": "DD/MM/YYYY",
  pl: "DD.MM.YYYY",
  "pt-br": "DD/MM/YYYY",
  pt: "DD/MM/YYYY",
  ro: "DD.MM.YYYY",
  ru: "DD.MM.YYYY",
  sd: "DD/MM/YYYY",
  se: "DD.MM.YYYY",
  si: "YYYY/MM/DD",
  sk: "DD.MM.YYYY",
  sl: "DD.MM.YYYY",
  sq: "DD/MM/YYYY",
  "sr-cyrl": "DD.MM.YYYY",
  sr: "DD.MM.YYYY",
  ss: "DD/MM/YYYY",
  sv: "YYYY-MM-DD",
  sw: "DD.MM.YYYY",
  ta: "DD/MM/YYYY",
  te: "DD/MM/YYYY",
  tet: "DD/MM/YYYY",
  tg: "DD/MM/YYYY",
  th: "DD/MM/YYYY",
  "tl-ph": "MM/D/YYYY",
  tlh: "DD.MM.YYYY",
  tr: "DD.MM.YYYY",
  tzl: "DD.MM.YYYY",
  "tzm-latn": "DD/MM/YYYY",
  tzm: "DD/MM/YYYY",
  "ug-cn": "YYYY-MM-DD",
  uk: "DD.MM.YYYY",
  ur: "DD/MM/YYYY",
  "uz-latn": "DD/MM/YYYY",
  uz: "DD/MM/YYYY",
  vi: "DD/MM/YYYY",
  "x-pseudo": "DD/MM/YYYY",
  yo: "DD/MM/YYYY",
  "zh-cn": "YYYY/MM/DD",
  "zh-hk": "YYYY/MM/DD",
  "zh-tw": "YYYY/MM/DD"
};

  ```
</details>

<details>
  <summary>Date-fns</summary>
  
  ```javascript
const localesMap = {
  af: "yyyy/MM/dd",
  "ar-DZ": "MM/dd/yyyy",
  "ar-MA": "MM/dd/yyyy",
  "ar-SA": "MM/dd/yyyy",
  az: "dd.MM.yyyy",
  be: "dd.MM.y",
  bg: "dd/MM/yyyy",
  bn: "MM/dd/yyyy",
  ca: "dd/MM/y",
  cs: "d.M.yy",
  cy: "dd/MM/yyyy",
  da: "dd/MM/y",
  de: "dd.MM.y",
  el: "d/M/yy",
  "en-AU": "dd/MM/yyyy",
  "en-CA": "yyyy-MM-dd",
  "en-GB": "dd/MM/yyyy",
  "en-US": "MM/dd/yyyy",
  eo: "yyyy-MM-dd",
  es: "dd/MM/y",
  et: "dd.MM.y",
  "fa-IR": "yyyy/MM/dd",
  fi: "d.M.y",
  "fr-CA": "yy-MM-dd",
  fr: "dd/MM/y",
  gl: "dd/MM/y",
  gu: "d/M/yy",
  he: "d.M.y",
  hi: "dd/MM/yyyy",
  hr: "dd. MM. y.",
  hu: "y. MM. dd.",
  hy: "dd.MM.yyyy",
  id: "d/M/yyyy",
  is: "d.MM.y",
  it: "dd/MM/y",
  ja: "y/MM/dd",
  ka: "dd/MM/yyyy",
  kk: "dd.MM.yyyy",
  ko: "y.MM.dd",
  lt: "y-MM-dd",
  lv: "dd.MM.y.",
  ms: "d/M/yyyy",
  nb: "dd.MM.y",
  nl: "dd-MM-y",
  nn: "dd.MM.y",
  pl: "dd.MM.y",
  "pt-BR": "dd/MM/yyyy",
  pt: "dd/MM/y",
  ro: "dd/MM/yyyy",
  ru: "dd.MM.y",
  sk: "d. M. y",
  sl: "d. MM. yy",
  "sr-Latn": "dd. MM. yy.",
  sr: "dd. MM. yy.",
  sv: "y-MM-dd",
  ta: "d/M/yy",
  te: "dd-MM-yy",
  th: "dd/MM/yyyy",
  tr: "dd.MM.yyyy",
  ug: "MM/dd/yyyy",
  uk: "dd.MM.y",
  vi: "dd/MM/y",
  "zh-CN": "yy-MM-dd",
  "zh-TW": "yy-MM-dd"
};

  ```
</details>