### PR TITLE
Add showLeftArrowButton and showRightArrowButton props to CalendarHeader

### DIFF
--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -417,6 +417,36 @@
         "name": "(day: DateIOType) => boolean"
       }
     },
+    "showLeftArrowButton": {
+      "defaultValue": {
+        "value": "true"
+      },
+      "description": "Show left arrow button?",
+      "name": "showLeftArrowButton",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
+        "name": "CalendarProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
+    "showRightArrowButton": {
+      "defaultValue": {
+        "value": "true"
+      },
+      "description": "Show right arrow button?",
+      "name": "showRightArrowButton",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
+        "name": "CalendarProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
     "onMonthChange": {
       "defaultValue": null,
       "description": "Callback firing on month change. Return promise to render spinner till it will not be resolved",
@@ -2123,6 +2153,36 @@
         "name": "(day: DateIOType) => boolean"
       }
     },
+    "showLeftArrowButton": {
+      "defaultValue": {
+        "value": "true"
+      },
+      "description": "Show left arrow button?",
+      "name": "showLeftArrowButton",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
+        "name": "CalendarProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
+    "showRightArrowButton": {
+      "defaultValue": {
+        "value": "true"
+      },
+      "description": "Show right arrow button?",
+      "name": "showRightArrowButton",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
+        "name": "CalendarProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
     "onMonthChange": {
       "defaultValue": null,
       "description": "Callback firing on month change. Return promise to render spinner till it will not be resolved",
@@ -2324,6 +2384,36 @@
       "required": false,
       "type": {
         "name": "(day: DateIOType) => boolean"
+      }
+    },
+    "showLeftArrowButton": {
+      "defaultValue": {
+        "value": "true"
+      },
+      "description": "Show left arrow button?",
+      "name": "showLeftArrowButton",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
+        "name": "CalendarProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
+    "showRightArrowButton": {
+      "defaultValue": {
+        "value": "true"
+      },
+      "description": "Show right arrow button?",
+      "name": "showRightArrowButton",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
+        "name": "CalendarProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
       }
     },
     "onMonthChange": {

--- a/lib/.size-snapshot.json
+++ b/lib/.size-snapshot.json
@@ -22,5 +22,29 @@
     "bundled": 517773,
     "minified": 198820,
     "gzipped": 38181
+  },
+  "build\\dist\\material-ui-pickers.esm.js": {
+    "bundled": 115769,
+    "minified": 65532,
+    "gzipped": 17485,
+    "treeshaked": {
+      "rollup": {
+        "code": 53930,
+        "import_statements": 2049
+      },
+      "webpack": {
+        "code": 61145
+      }
+    }
+  },
+  "build\\dist\\material-ui-pickers.umd.js": {
+    "bundled": 565154,
+    "minified": 211328,
+    "gzipped": 42114
+  },
+  "build\\dist\\material-ui-pickers.umd.min.js": {
+    "bundled": 505255,
+    "minified": 193159,
+    "gzipped": 37437
   }
 }

--- a/lib/src/Picker/makePickerWithState.tsx
+++ b/lib/src/Picker/makePickerWithState.tsx
@@ -68,6 +68,8 @@ export function makePickerWithStateAndWrapper<
       rightArrowButtonProps,
       rightArrowIcon,
       shouldDisableDate,
+      showLeftArrowButton,
+      showRightArrowButton,
       strictCompareDates,
       timeIcon,
       ToolbarComponent = DefaultToolbarComponent,
@@ -129,6 +131,8 @@ export function makePickerWithStateAndWrapper<
           rightArrowButtonProps={rightArrowButtonProps}
           rightArrowIcon={rightArrowIcon}
           shouldDisableDate={shouldDisableDate}
+          showLeftArrowButton={showLeftArrowButton}
+          showRightArrowButton={showRightArrowButton}
           strictCompareDates={strictCompareDates}
           timeIcon={timeIcon}
           ToolbarComponent={ToolbarComponent}

--- a/lib/src/constants/prop-types.ts
+++ b/lib/src/constants/prop-types.ts
@@ -28,6 +28,8 @@ export const datePickerDefaultProps = {
   minDateMessage: 'Date should not be before minimal date',
   maxDateMessage: 'Date should not be after maximal date',
   allowKeyboardControl: true,
+  showLeftArrowButton: true,
+  showRightArrowButton: true,
 } as BaseDatePickerProps;
 
 export const dateTimePickerDefaultProps = {

--- a/lib/src/views/Calendar/Calendar.tsx
+++ b/lib/src/views/Calendar/Calendar.tsx
@@ -53,6 +53,16 @@ export interface CalendarProps {
   rightArrowButtonProps?: Partial<IconButtonProps>;
   /** Disable specific date @DateIOType */
   shouldDisableDate?: (day: MaterialUiPickersDate) => boolean;
+  /**
+   * Show left arrow button?
+   * @default true
+   */
+  showLeftArrowButton?: boolean;
+  /**
+   * Show right arrow button?
+   * @default true
+   */
+  showRightArrowButton?: boolean;
   /** Callback firing on month change. Return promise to render spinner till it will not be resolved @DateIOType */
   onMonthChange?: (date: MaterialUiPickersDate) => void | Promise<void>;
   /** Custom loading indicator  */

--- a/lib/src/views/Calendar/CalendarHeader.tsx
+++ b/lib/src/views/Calendar/CalendarHeader.tsx
@@ -25,6 +25,16 @@ export interface CalendarWithHeaderProps
   /** Right arrow icon */
   rightArrowIcon?: React.ReactNode;
   /**
+   * Show left arrow button?
+   * @default true
+   */
+  showLeftArrowButton?: boolean;
+  /**
+   * Show right arrow button?
+   * @default true
+   */
+  showRightArrowButton?: boolean;
+  /**
    * Props to pass to left arrow button
    * @type {Partial<IconButtonProps>}
    */
@@ -91,6 +101,8 @@ export const CalendarHeader: React.SFC<CalendarWithHeaderProps> = ({
   rightArrowIcon,
   leftArrowButtonProps,
   rightArrowButtonProps,
+  showLeftArrowButton,
+  showRightArrowButton,
   changeView,
   onMonthChange,
   minDate,
@@ -187,30 +199,33 @@ export const CalendarHeader: React.SFC<CalendarWithHeaderProps> = ({
 
         <Fade in={view === 'date'}>
           <div>
-            <IconButton
-              data-mui-test="previous-month"
-              size="small"
-              {...leftArrowButtonProps}
-              disabled={isPreviousMonthDisabled}
-              onClick={selectPreviousMonth}
-              className={clsx(
-                classes.iconButton,
-                classes.previousMonthButton,
-                leftArrowButtonProps?.className
-              )}
-            >
-              {isRtl ? rightArrowIcon : leftArrowIcon}
-            </IconButton>
-
-            <IconButton
-              size="small"
-              {...rightArrowButtonProps}
-              disabled={isNextMonthDisabled}
-              onClick={selectNextMonth}
-              className={clsx(classes.iconButton, rightArrowButtonProps?.className)}
-            >
-              {isRtl ? leftArrowIcon : rightArrowIcon}
-            </IconButton>
+            {showLeftArrowButton && (
+              <IconButton
+                data-mui-test="previous-month"
+                size="small"
+                {...leftArrowButtonProps}
+                disabled={isPreviousMonthDisabled}
+                onClick={selectPreviousMonth}
+                className={clsx(
+                  classes.iconButton,
+                  classes.previousMonthButton,
+                  leftArrowButtonProps?.className
+                )}
+              >
+                {isRtl ? rightArrowIcon : leftArrowIcon}
+              </IconButton>
+            )}
+            {showRightArrowButton && (
+              <IconButton
+                size="small"
+                {...rightArrowButtonProps}
+                disabled={isNextMonthDisabled}
+                onClick={selectNextMonth}
+                className={clsx(classes.iconButton, rightArrowButtonProps?.className)}
+              >
+                {isRtl ? leftArrowIcon : rightArrowIcon}
+              </IconButton>
+            )}
           </div>
         </Fade>
       </div>


### PR DESCRIPTION
Add ability to hide left and right arrow buttons in calendar header. Useful if you want to control the calendar externally.

Still needs tests writing but is this feature something that would be considered?