### PR TITLE
Fix missing adapters in build

### DIFF
--- a/lib/.size-snapshot.json
+++ b/lib/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "build/dist/material-ui-pickers.esm.js": {
-    "bundled": 115786,
-    "minified": 65541,
-    "gzipped": 17489,
+    "bundled": 133250,
+    "minified": 73782,
+    "gzipped": 19715,
     "treeshaked": {
       "rollup": {
-        "code": 53939,
+        "code": 60577,
         "import_statements": 2049
       },
       "webpack": {
-        "code": 61154
+        "code": 68042
       }
     }
   },
   "build/dist/material-ui-pickers.umd.js": {
-    "bundled": 578392,
-    "minified": 217270,
-    "gzipped": 42969
+    "bundled": 587212,
+    "minified": 218097,
+    "gzipped": 44517
   },
   "build/dist/material-ui-pickers.umd.min.js": {
-    "bundled": 517773,
-    "minified": 198820,
-    "gzipped": 38181
+    "bundled": 527043,
+    "minified": 199634,
+    "gzipped": 39489
   }
 }

--- a/lib/adapter/date-fns.ts
+++ b/lib/adapter/date-fns.ts
@@ -1,3 +1,1 @@
 export { default } from '@date-io/date-fns';
-
-export const inputMaskFromLocale = () => {};

--- a/lib/copy.js
+++ b/lib/copy.js
@@ -37,8 +37,8 @@ function createPackageFile() {
         ...other,
         private: false,
         main: './dist/material-ui-pickers.js',
-        module: './esm/index.js',
-        typings: './index.d.ts',
+        module: './index.js',
+        typings: './src/index.d.ts',
       };
 
       return new Promise(resolve => {

--- a/lib/rollup.config.js
+++ b/lib/rollup.config.js
@@ -1,6 +1,5 @@
 import path from 'path';
 import reactIs from 'react-is';
-// @ts-ignore
 import pkg from './package.json';
 // named exports detectors
 import propTypes from 'prop-types';
@@ -66,6 +65,11 @@ const onwarn = warning => {
   throw Error(String(warning));
 };
 
+const getCommonPlugins = ({ esm }) => [
+  nodeResolve({ extensions }),
+  babel(getBabelOptions({ useESModules: esm })),
+];
+
 export default [
   {
     input,
@@ -76,7 +80,7 @@ export default [
       format: 'cjs',
       sourcemap: true,
     },
-    plugins: [nodeResolve({ extensions }), babel(getBabelOptions({ useESModules: false }))],
+    plugins: getCommonPlugins({ esm: false }),
   },
 
   {
@@ -94,11 +98,11 @@ export default [
     external,
     onwarn,
     output: {
-      dir: 'build/esm',
+      dir: 'build',
       format: 'esm',
       sourcemap: true,
     },
-    plugins: [nodeResolve({ extensions }), babel(getBabelOptions({ useESModules: true }))],
+    plugins: getCommonPlugins({ esm: true }),
   },
 
   {
@@ -110,11 +114,41 @@ export default [
       format: 'esm',
       sourcemap: true,
     },
-    plugins: [
-      nodeResolve({ extensions }),
-      babel(getBabelOptions({ useESModules: true })),
-      sizeSnapshot(),
-    ],
+    plugins: [...getCommonPlugins({ esm: true }), sizeSnapshot()],
+  },
+
+  {
+    input: {
+      'date-fns': './adapter/date-fns',
+      luxon: './adapter/luxon',
+      moment: './adapter/moment',
+      dayjs: './adapter/dayjs',
+    },
+    external,
+    onwarn,
+    output: {
+      dir: 'build/adapter',
+      format: 'esm',
+      sourcemap: true,
+    },
+    plugins: getCommonPlugins({ esm: true }),
+  },
+
+  {
+    input: {
+      'date-fns.cjs': './adapter/date-fns',
+      'luxon.cjs': './adapter/luxon',
+      'moment.cjs': './adapter/moment',
+      'dayjs.cjs': './adapter/dayjs',
+    },
+    external,
+    onwarn,
+    output: {
+      dir: 'build/adapter',
+      format: 'cjs',
+      sourcemap: true,
+    },
+    plugins: getCommonPlugins({ esm: false }),
   },
 
   {
@@ -128,8 +162,7 @@ export default [
       file: 'build/dist/material-ui-pickers.umd.js',
     },
     plugins: [
-      nodeResolve({ extensions }),
-      babel(getBabelOptions({ useESModules: true })),
+      ...getCommonPlugins({ esm: true }),
       commonjs(commonjsOptions),
       replace({ 'process.env.NODE_ENV': JSON.stringify('development') }),
       sizeSnapshot(),
@@ -154,8 +187,7 @@ export default [
       file: 'build/dist/material-ui-pickers.umd.min.js',
     },
     plugins: [
-      nodeResolve({ extensions }),
-      babel(getBabelOptions({ useESModules: true })),
+      ...getCommonPlugins({ esm: true }),
       commonjs(commonjsOptions),
       replace({ 'process.env.NODE_ENV': JSON.stringify('production') }),
       sizeSnapshot(),

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "commonjs",
     "outDir": "build",
     "declaration": true,
+    "emitDeclarationOnly": true,
     "target": "es5",
     "lib": ["dom", "es2016"],
     "types": ["jest"],
@@ -17,6 +18,6 @@
     "suppressImplicitAnyIndexErrors": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts*", "./typings.d.ts"],
-  "exclude": ["./src/__tests__/**/*", "build", "cypress/**/*.ts*"]
+  "include": ["src/**/*.ts*", "adapter/**/*.ts*", "./typings.d.ts"],
+  "exclude": ["./src/__tests__/**/*", "./rollup.config.js", "build", "cypress/**/*.ts*"]
 }


### PR DESCRIPTION
And finally fix a problem with conflicting imports 
```js
import { DatePicker } from '@material-ui/pickers'
// vs 
import { MuiPickersUtilsProvider } from '@materail-ui/pickers/MuiPickersUtilsProvider'
```

Will not errors because of different context instance anymore 👍 