### PR TITLE
Api changes

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -1,0 +1,7 @@
+version: 1
+snapshot:
+  percy-css: |
+    #codefund {
+      display: none;
+    }
+  |

--- a/docs/_shared/Ad.tsx
+++ b/docs/_shared/Ad.tsx
@@ -36,6 +36,10 @@ const Ad: React.FC = () => {
     }
   }, []);
 
+  if (process.env.VISUAL_TESTING) {
+    return null;
+  }
+
   return (
     <Grid container>
       <span id="codefund-script-position" />

--- a/docs/_shared/PropTypesTable.tsx
+++ b/docs/_shared/PropTypesTable.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import Code from './Code';
 import FuzzySearch from 'fuzzy-search';
+import ReactMarkdown from 'react-markdown';
 import PropTypesDoc from '../prop-types.json';
 import SearchBar from 'material-ui-search-bar';
 import React, { useMemo, useState } from 'react';
@@ -141,7 +142,7 @@ const PropTypesTableLazy: React.FC<PropTypesTableProps> = ({ disableHeader, src 
                 </TableCell>
 
                 <TableCell className={classes.description}>
-                  <span dangerouslySetInnerHTML={{ __html: prop.description }} />
+                  <ReactMarkdown source={prop.description} />
                 </TableCell>
               </TableRow>
             ))}

--- a/docs/pages/api/props.tsx
+++ b/docs/pages/api/props.tsx
@@ -7,7 +7,7 @@ import { PageMeta } from '_shared/PageMeta';
 import { WithRouterProps, withRouter } from 'next/router';
 import { Typography, Grid, makeStyles } from '@material-ui/core';
 
-const internalComponents = ['Calendar', 'ClockView'];
+const internalComponents = ['Calendar', 'ClockView', 'Day'];
 const useStyles = makeStyles(theme => ({
   kawaiiIcon: {
     marginTop: 48,

--- a/docs/pages/demo/datepicker/AdvancedKeyboard.example.jsx
+++ b/docs/pages/demo/datepicker/AdvancedKeyboard.example.jsx
@@ -12,7 +12,7 @@ function AdvancedKeyboardExample(props) {
         variant="outlined"
         label="Advanced keyboard"
         placeholder="2018/01/01"
-        format={props.__willBeReplacedGetFormatString({
+        inputFormat={props.__willBeReplacedGetFormatString({
           moment: 'YYYY/MM/DD',
           dateFns: 'yyyy/MM/dd',
         })}

--- a/docs/pages/demo/datepicker/CustomDay.example.jsx
+++ b/docs/pages/demo/datepicker/CustomDay.example.jsx
@@ -63,7 +63,7 @@ function WeekPicker(props) {
       value={selectedDate}
       onChange={handleDateChange}
       renderDay={renderWeekPickerDay}
-      inputFormat={props.__willBeReplacedGetFormatString({
+      inputinputFormat={props.__willBeReplacedGetFormatString({
         moment: `[Week of] MMM D`,
         dateFns: `'Week of' MMM d`,
       })}

--- a/docs/pages/demo/datepicker/CustomDay.example.jsx
+++ b/docs/pages/demo/datepicker/CustomDay.example.jsx
@@ -63,9 +63,9 @@ function WeekPicker(props) {
       value={selectedDate}
       onChange={handleDateChange}
       renderDay={renderWeekPickerDay}
-      inputinputFormat={props.__willBeReplacedGetFormatString({
+      inputFormat={props.__willBeReplacedGetFormatString({
         moment: `[Week of] MMM D`,
-        dateFns: `'Week of' MMM d`,
+        dateFns: "'Week of' MMM d",
       })}
     />
   );

--- a/docs/pages/demo/datepicker/CustomDay.example.jsx
+++ b/docs/pages/demo/datepicker/CustomDay.example.jsx
@@ -1,36 +1,38 @@
 import clsx from 'clsx';
-import format from 'date-fns/format';
-import isValid from 'date-fns/isValid';
+import React, { useState } from 'react';
 import isSameDay from 'date-fns/isSameDay';
 import endOfWeek from 'date-fns/endOfWeek';
-import React, { PureComponent } from 'react';
 import startOfWeek from 'date-fns/startOfWeek';
 import isWithinInterval from 'date-fns/isWithinInterval';
-import { DatePicker } from '@material-ui/pickers';
-import { createStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core';
+import { DatePicker, Day } from '@material-ui/pickers';
 // this guy required only on the docs site to work with dynamic date library
 import { makeJSDateObject } from '../../../utils/helpers';
-import { IconButton, withStyles } from '@material-ui/core';
 
-class CustomElements extends PureComponent {
-  state = {
-    selectedDate: new Date(),
-  };
+const useStyles = makeStyles(theme => ({
+  highlight: {
+    borderRadius: 0,
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.common.white,
+    '&:hover, &:focus': {
+      backgroundColor: theme.palette.primary.dark,
+    },
+  },
+  firstHighlight: {
+    borderTopLeftRadius: '50%',
+    borderBottomLeftRadius: '50%',
+  },
+  endHighlight: {
+    borderTopRightRadius: '50%',
+    borderBottomRightRadius: '50%',
+  },
+}));
 
-  handleWeekChange = date => {
-    this.setState({ selectedDate: startOfWeek(makeJSDateObject(date)) });
-  };
+function WeekPicker(props) {
+  const classes = useStyles(props);
+  const [selectedDate, handleDateChange] = useState(new Date());
 
-  formatWeekSelectLabel = (date, invalidLabel) => {
-    let dateClone = makeJSDateObject(date);
-
-    return dateClone && isValid(dateClone)
-      ? `Week of ${format(startOfWeek(dateClone), 'MMM do')}`
-      : invalidLabel;
-  };
-
-  renderWrappedWeekDay = (date, selectedDate, dayInCurrentMonth) => {
-    const { classes } = this.props;
+  const renderWeekPickerDay = (date, selectedDate, DayComponentProps) => {
     let dateClone = makeJSDateObject(date);
     let selectedDateClone = makeJSDateObject(selectedDate);
 
@@ -41,81 +43,32 @@ class CustomElements extends PureComponent {
     const isFirstDay = isSameDay(dateClone, start);
     const isLastDay = isSameDay(dateClone, end);
 
-    const wrapperClassName = clsx({
-      [classes.highlight]: dayIsBetween,
-      [classes.firstHighlight]: isFirstDay,
-      [classes.endHighlight]: isLastDay,
-    });
-
-    const dayClassName = clsx(classes.day, {
-      [classes.nonCurrentMonthDay]: !dayInCurrentMonth,
-      [classes.highlightNonCurrentMonthDay]: !dayInCurrentMonth && dayIsBetween,
-    });
-
     return (
-      <div className={wrapperClassName}>
-        <IconButton className={dayClassName}>
-          <span> {format(dateClone, 'd')} </span>
-        </IconButton>
-      </div>
+      <Day
+        {...DayComponentProps}
+        disableMargin
+        className={clsx({
+          [classes.highlight]: dayIsBetween,
+          [classes.firstHighlight]: isFirstDay,
+          [classes.endHighlight]: isLastDay,
+        })}
+      />
     );
   };
 
-  render() {
-    const { selectedDate } = this.state;
-
-    return (
-      <DatePicker
-        label="Week picker"
-        value={selectedDate}
-        onChange={this.handleWeekChange}
-        renderDay={this.renderWrappedWeekDay}
-        labelFunc={this.formatWeekSelectLabel}
-      />
-    );
-  }
+  return (
+    <DatePicker
+      showDaysOutsideCurrentMonth
+      label="Week picker"
+      value={selectedDate}
+      onChange={handleDateChange}
+      renderDay={renderWeekPickerDay}
+      inputFormat={props.__willBeReplacedGetFormatString({
+        moment: `[Week of] MMM D`,
+        dateFns: `'Week of' MMM d`,
+      })}
+    />
+  );
 }
 
-const styles = createStyles(theme => ({
-  dayWrapper: {
-    position: 'relative',
-  },
-  day: {
-    width: 36,
-    height: 36,
-    fontSize: theme.typography.caption.fontSize,
-    margin: '0 2px',
-    color: 'inherit',
-  },
-  customDayHighlight: {
-    position: 'absolute',
-    top: 0,
-    bottom: 0,
-    left: '2px',
-    right: '2px',
-    border: `1px solid ${theme.palette.secondary.main}`,
-    borderRadius: '50%',
-  },
-  nonCurrentMonthDay: {
-    color: theme.palette.text.disabled,
-  },
-  highlightNonCurrentMonthDay: {
-    color: '#676767',
-  },
-  highlight: {
-    background: theme.palette.primary.main,
-    color: theme.palette.common.white,
-  },
-  firstHighlight: {
-    extend: 'highlight',
-    borderTopLeftRadius: '50%',
-    borderBottomLeftRadius: '50%',
-  },
-  endHighlight: {
-    extend: 'highlight',
-    borderTopRightRadius: '50%',
-    borderBottomRightRadius: '50%',
-  },
-}));
-
-export default withStyles(styles)(CustomElements);
+export default WeekPicker;

--- a/docs/pages/demo/datepicker/DatePickers.example.jsx
+++ b/docs/pages/demo/datepicker/DatePickers.example.jsx
@@ -12,7 +12,7 @@ function DatePickersVariants(props) {
         value={selectedDate}
         placeholder="10/10/2018"
         onChange={date => handleDateChange(date)}
-        format={props.__willBeReplacedGetFormatString({
+        inputFormat={props.__willBeReplacedGetFormatString({
           moment: 'MM/DD/YYYY',
           dateFns: 'MM/dd/yyyy',
         })}

--- a/docs/pages/demo/datepicker/ServerRequest.example.jsx
+++ b/docs/pages/demo/datepicker/ServerRequest.example.jsx
@@ -32,9 +32,8 @@ function ServerRequest() {
           const isSelected =
             DayComponentProps.isInCurrentMonth && selectedDays.includes(date.getDate());
 
-          // You can also use our internal <Day /> component
           return (
-            <Badge badgeContent={isSelected ? '🌚' : undefined}>
+            <Badge overlap="circle" badgeContent={isSelected ? '🌚' : undefined}>
               <Day {...DayComponentProps} />
             </Badge>
           );

--- a/docs/pages/demo/datepicker/ServerRequest.example.jsx
+++ b/docs/pages/demo/datepicker/ServerRequest.example.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Badge } from '@material-ui/core';
-import { DatePicker } from '@material-ui/pickers';
+import { DatePicker, Day } from '@material-ui/pickers';
 import { makeJSDateObject } from '../../../utils/helpers';
 
 function getRandomNumber(min, max) {
@@ -24,16 +24,20 @@ function ServerRequest() {
   return (
     <>
       <DatePicker
-        label="With server data"
         value={selectedDate}
         onChange={date => handleDateChange(date)}
         onMonthChange={handleMonthChange}
-        renderDay={(day, selectedDate, isInCurrentMonth, dayComponent) => {
+        renderDay={(day, selectedDate, DayComponentProps) => {
           const date = makeJSDateObject(day); // skip this step, it is required to support date libs
-          const isSelected = isInCurrentMonth && selectedDays.includes(date.getDate());
+          const isSelected =
+            DayComponentProps.isInCurrentMonth && selectedDays.includes(date.getDate());
 
           // You can also use our internal <Day /> component
-          return <Badge badgeContent={isSelected ? '🌚' : undefined}>{dayComponent}</Badge>;
+          return (
+            <Badge badgeContent={isSelected ? '🌚' : undefined}>
+              <Day {...DayComponentProps} />
+            </Badge>
+          );
         }}
       />
     </>

--- a/docs/pages/demo/datepicker/index.mdx
+++ b/docs/pages/demo/datepicker/index.mdx
@@ -61,7 +61,8 @@ We are providing default localized formats, but you can change this behaviour wi
 
 #### Customization
 
-The displaying of dates is heavily cusomizable. Thus you can add badges or fully change displaying of day.
+The displaying of dates is heavily cusomizable. Use `renderDay` function to customize view of the day.
+You can leverage our internal [Day](/api/Day) component, and render it in default way by spreading `dayProps` argument.
 
 <Example source={CustomDay} />
 

--- a/docs/pages/demo/datetime-picker/CustomDateTimePicker.example.jsx
+++ b/docs/pages/demo/datetime-picker/CustomDateTimePicker.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
+import AlarmIcon from '@material-ui/icons/Alarm';
 import SnoozeIcon from '@material-ui/icons/Snooze';
-import AlarmIcon from '@material-ui/icons/AddAlarm';
-import { IconButton, InputAdornment } from '@material-ui/core';
+import ClockIcon from '@material-ui/icons/AccessTime';
 import { DateTimePicker, MobileDateTimePicker } from '@material-ui/pickers';
 
 function CustomDateTimePicker(props) {
@@ -14,25 +14,20 @@ function CustomDateTimePicker(props) {
         autoOk
         disableFuture
         hideTabs
-        ampm={false}
+        showTodayButton
+        todayLabel="now"
+        openTo="hours"
         value={selectedDate}
         onChange={date => handleDateChange(date)}
-        allowKeyboardControl={false}
         minDate={new Date('2018-01-01')}
         helperText="Hardcoded helper text"
         leftArrowIcon={<AlarmIcon />}
-        leftArrowButtonProps={{ 'aria-label': 'Prev month' }}
-        rightArrowButtonProps={{ 'aria-label': 'Next month' }}
         rightArrowIcon={<SnoozeIcon />}
-        InputProps={{
-          endAdornment: (
-            <InputAdornment position="end">
-              <IconButton>
-                <AlarmIcon />
-              </IconButton>
-            </InputAdornment>
-          ),
-        }}
+        leftArrowButtonText="Open previous month"
+        rightArrowButtonText="Open next month"
+        keyboardIcon={<ClockIcon />}
+        minTime={new Date(0, 0, 0, 9)}
+        maxTime={new Date(0, 0, 0, 20)}
       />
 
       <MobileDateTimePicker
@@ -41,7 +36,7 @@ function CustomDateTimePicker(props) {
         label="With error handler"
         onError={console.log}
         minDate={new Date('2018-01-01T00:00')}
-        format={props.__willBeReplacedGetFormatString({
+        inputFormat={props.__willBeReplacedGetFormatString({
           moment: 'YYYY/MM/DD hh:mm A',
           dateFns: 'yyyy/MM/dd hh:mm a',
         })}

--- a/docs/pages/demo/datetime-picker/DateTimePickers.example.jsx
+++ b/docs/pages/demo/datetime-picker/DateTimePickers.example.jsx
@@ -28,7 +28,7 @@ function DateTimePickerDemo(props) {
         value={selectedDate}
         onChange={handleDateChange}
         onError={console.log}
-        format={props.__willBeReplacedGetFormatString({
+        inputFormat={props.__willBeReplacedGetFormatString({
           moment: 'YYYY/MM/DD HH:mm',
           dateFns: 'yyyy/MM/dd HH:mm',
         })}

--- a/docs/pages/demo/timepicker/SecondsTimePicker.example.jsx
+++ b/docs/pages/demo/timepicker/SecondsTimePicker.example.jsx
@@ -10,7 +10,7 @@ function SecondsTimePicker() {
         ampm={false}
         openTo="hours"
         views={['hours', 'minutes', 'seconds']}
-        format="HH:mm:ss"
+        inputFormat="HH:mm:ss"
         label="With seconds"
         value={selectedDate}
         onChange={date => handleDateChange(date)}
@@ -20,7 +20,7 @@ function SecondsTimePicker() {
         ampmInClock
         openTo="minutes"
         views={['minutes', 'seconds']}
-        format="mm:ss"
+        inputFormat="mm:ss"
         label="Minutes and seconds"
         value={selectedDate}
         onChange={date => handleDateChange(date)}

--- a/docs/pages/guides/ControllingProgrammatically.example.jsx
+++ b/docs/pages/guides/ControllingProgrammatically.example.jsx
@@ -23,7 +23,7 @@ function ControllingProgrammaticallyExample() {
         onOpen={() => setIsOpen(true)}
         onClose={() => setIsOpen(false)}
         label="Open me from button"
-        format="d MMM yyyy"
+        inputFormat="d MMM yyyy"
         value={selectedDate}
         onChange={handleDateChange}
       />

--- a/docs/pages/guides/Formats.example.jsx
+++ b/docs/pages/guides/Formats.example.jsx
@@ -19,7 +19,7 @@ function DateFnsLocalizationExample() {
       <DatePicker
         clearable
         helperText="Localization done right"
-        format="d MMM yyyy"
+        inputFormat="d MMM yyyy"
         value={selectedDate}
         onChange={handleDateChange}
         clearLabel="vider"

--- a/docs/pages/guides/Formik.example.jsx
+++ b/docs/pages/guides/Formik.example.jsx
@@ -13,7 +13,7 @@ const DatePickerField = ({ field, form, ...other }) => {
       disablePast
       name={field.name}
       value={field.value}
-      format="dd/MM/yyyy"
+      inputFormat="dd/MM/yyyy"
       helperText={currentError}
       error={Boolean(currentError)}
       onError={error => {

--- a/docs/pages/guides/ReduxForm.example.jsx
+++ b/docs/pages/guides/ReduxForm.example.jsx
@@ -23,7 +23,7 @@ const DateField = props => {
     <DatePicker
       {...inputProps}
       {...others}
-      format="dd/MM/yyyy"
+      inputFormat="dd/MM/yyyy"
       value={value ? new Date(value) : null}
       disabled={submitting}
       onBlur={() => onBlur(value ? new Date(value).toISOString() : null)}

--- a/docs/pages/localization/Date-fns-customized.example.jsx
+++ b/docs/pages/localization/Date-fns-customized.example.jsx
@@ -68,7 +68,7 @@ function DateFnsLocalizationExample() {
       <DatePicker
         value={selectedDate}
         onChange={handleDateChange}
-        format={localeFormatMap[locale]}
+        inputFormat={localeFormatMap[locale]}
         cancelLabel={localeCancelLabelMap[locale]}
         InputProps={{
           endAdornment: (

--- a/docs/pages/localization/Hijri.example.jsx
+++ b/docs/pages/localization/Hijri.example.jsx
@@ -19,9 +19,9 @@ function HijriExample() {
         okLabel="موافق"
         cancelLabel="الغاء"
         clearLabel="مسح"
-        labelFunc={date => (date ? date.format('iYYYY/iMM/iDD') : '')}
+        inputFormat="iYYYY/iMM/iDD"
         value={selectedDate}
-        onChange={handleDateChange}
+        onChange={date => handleDateChange(date)}
         minDate="1937-03-14"
         maxDate="2076-11-26"
       />
@@ -31,17 +31,17 @@ function HijriExample() {
         okLabel="موافق"
         cancelLabel="الغاء"
         clearLabel="مسح"
-        labelFunc={date => (date ? date.format('hh:mm A') : '')}
+        inputFormat="hh:mm A"
         value={selectedDate}
-        onChange={handleDateChange}
+        onChange={date => handleDateChange(date)}
       />
 
       <DateTimePicker
         okLabel="موافق"
         cancelLabel="الغاء"
-        labelFunc={date => (date ? date.format('iYYYY/iMM/iDD hh:mm A') : '')}
+        inputFormat="iYYYY/iMM/iDD"
         value={selectedDate}
-        onChange={handleDateChange}
+        onChange={date => handleDateChange(date)}
         minDate="1937-03-14"
         maxDate="2076-11-26"
       />

--- a/docs/pages/localization/Persian.example.jsx
+++ b/docs/pages/localization/Persian.example.jsx
@@ -21,9 +21,9 @@ function PersianExample() {
         okLabel="تأیید"
         cancelLabel="لغو"
         clearLabel="پاک کردن"
-        labelFunc={date => (date ? date.format('jYYYY/jMM/jDD') : '')}
+        inputFormat="jYYYY/iMM/iDD"
         value={selectedDate}
-        onChange={handleDateChange}
+        onChange={date => handleDateChange(date)}
       />
 
       <TimePicker
@@ -31,17 +31,17 @@ function PersianExample() {
         okLabel="تأیید"
         cancelLabel="لغو"
         clearLabel="پاک کردن"
-        labelFunc={date => (date ? date.format('hh:mm A') : '')}
+        inputFormat="hh:mm A"
         value={selectedDate}
-        onChange={handleDateChange}
+        onChange={date => handleDateChange(date)}
       />
 
       <DateTimePicker
         okLabel="تأیید"
         cancelLabel="لغو"
-        labelFunc={date => (date ? date.format('jYYYY/jMM/jDD hh:mm A') : '')}
+        inputFormat="jYYYY/iMM/iDD"
         value={selectedDate}
-        onChange={handleDateChange}
+        onChange={date => handleDateChange(date)}
       />
     </MuiPickersUtilsProvider>
   );

--- a/docs/pages/localization/calendar-systems.mdx
+++ b/docs/pages/localization/calendar-systems.mdx
@@ -17,10 +17,10 @@ Install the specified npm packages below for Jalaali or Hijri depending on which
 
 #### Jalaali calendar system
 
-Install `@date-io/jalaali` package from npm.
+Install `@date-io/jalaali` and `moment-jalaali` packages from npm.
 
 ```
-npm install @date-io/jalaali
+npm install @date-io/jalaali moment-jalaali
 ```
 
 #### Example

--- a/docs/pages/regression/Regression.tsx
+++ b/docs/pages/regression/Regression.tsx
@@ -44,7 +44,7 @@ function Regression() {
           autoOk
           id="keyboard-mask-datepicker"
           {...sharedProps}
-          format="MM/dd/yyyy"
+          inputFormat="MM/dd/yyyy"
         />
         <DesktopDatePicker
           autoOk

--- a/docs/pages/regression/RegressionDay.tsx
+++ b/docs/pages/regression/RegressionDay.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { IUtils } from '@date-io/core/IUtils';
-import { IconButtonProps } from '@material-ui/core/IconButton';
+import { Day, DayProps } from '@material-ui/pickers';
 
 export const createRegressionDay = (utils: IUtils<any>) => (
   day: any,
   selectedDate: any,
-  dayInCurrentMonth: boolean,
-  dayComponent: React.ReactElement<IconButtonProps>
+  dayProps: DayProps
 ) => {
-  return <span data-day={utils.formatByString(day, 'dd/MM/yyyy')}>{dayComponent}</span>;
+  return <Day {...dayProps} data-day={utils.formatByString(day, 'dd/MM/yyyy')} />;
 };

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -827,23 +827,8 @@
       "defaultValue": {
         "value": "' '"
       },
-      "description": "Message displaying in text field, if null passed",
+      "description": "Message displaying in read-only text field when null passed",
       "name": "emptyLabel",
-      "parent": {
-        "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
-        "name": "DateInputProps"
-      },
-      "required": false,
-      "type": {
-        "name": "string"
-      }
-    },
-    "invalidLabel": {
-      "defaultValue": {
-        "value": "'unknown'"
-      },
-      "description": "Message displaying in text field if date is invalid (doesn't work in keyboard mode)",
-      "name": "invalidLabel",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"
@@ -1446,23 +1431,8 @@
       "defaultValue": {
         "value": "' '"
       },
-      "description": "Message displaying in text field, if null passed",
+      "description": "Message displaying in read-only text field when null passed",
       "name": "emptyLabel",
-      "parent": {
-        "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
-        "name": "DateInputProps"
-      },
-      "required": false,
-      "type": {
-        "name": "string"
-      }
-    },
-    "invalidLabel": {
-      "defaultValue": {
-        "value": "'unknown'"
-      },
-      "description": "Message displaying in text field if date is invalid (doesn't work in keyboard mode)",
-      "name": "invalidLabel",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"
@@ -1901,23 +1871,8 @@
       "defaultValue": {
         "value": "' '"
       },
-      "description": "Message displaying in text field, if null passed",
+      "description": "Message displaying in read-only text field when null passed",
       "name": "emptyLabel",
-      "parent": {
-        "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
-        "name": "DateInputProps"
-      },
-      "required": false,
-      "type": {
-        "name": "string"
-      }
-    },
-    "invalidLabel": {
-      "defaultValue": {
-        "value": "'unknown'"
-      },
-      "description": "Message displaying in text field if date is invalid (doesn't work in keyboard mode)",
-      "name": "invalidLabel",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -568,10 +568,10 @@
         "name": "boolean"
       }
     },
-    "format": {
+    "inputFormat": {
       "defaultValue": null,
       "description": "Format string",
-      "name": "format",
+      "name": "inputFormat",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
         "name": "BasePickerProps"
@@ -1200,10 +1200,10 @@
         "name": "boolean"
       }
     },
-    "format": {
+    "inputFormat": {
       "defaultValue": null,
       "description": "Format string",
-      "name": "format",
+      "name": "inputFormat",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
         "name": "BasePickerProps"
@@ -1668,10 +1668,10 @@
         "name": "boolean"
       }
     },
-    "format": {
+    "inputFormat": {
       "defaultValue": null,
       "description": "Format string",
-      "name": "format",
+      "name": "inputFormat",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
         "name": "BasePickerProps"

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -249,6 +249,21 @@
         "name": "(date: DateIOType) => void"
       }
     },
+    "disableHighlightToday": {
+      "defaultValue": {
+        "value": "false"
+      },
+      "description": "Disable highlighting today date with a circle",
+      "name": "disableHighlightToday",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
     "showDaysOutsideCurrentMonth": {
       "defaultValue": {
         "value": "false"
@@ -2214,6 +2229,21 @@
         "name": "(date: DateIOType) => void"
       }
     },
+    "disableHighlightToday": {
+      "defaultValue": {
+        "value": "false"
+      },
+      "description": "Disable highlighting today date with a circle",
+      "name": "disableHighlightToday",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
     "showDaysOutsideCurrentMonth": {
       "defaultValue": {
         "value": "false"
@@ -2572,6 +2602,21 @@
         "name": "Element"
       }
     },
+    "disableHighlightToday": {
+      "defaultValue": {
+        "value": "false"
+      },
+      "description": "Disable highlighting today date with a circle",
+      "name": "disableHighlightToday",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
     "showDaysOutsideCurrentMonth": {
       "defaultValue": {
         "value": "false"
@@ -2737,6 +2782,21 @@
       },
       "description": "Display disabled dates outside the current month",
       "name": "showDaysOutsideCurrentMonth",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
+    "disableHighlightToday": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Disable highlighting today date with a circle",
+      "name": "disableHighlightToday",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
         "name": "DayProps"

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -64,7 +64,7 @@
       "defaultValue": {
         "value": false
       },
-      "description": "If true today button will be displayed <b>Note*</b> that clear button has higher priority",
+      "description": "If true today button will be displayed. **Note** that clear button has higher priority",
       "name": "showTodayButton",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/MobileWrapper.tsx",
@@ -195,7 +195,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "If true today button will be displayed <b>Note*</b> that clear button has higher priority",
+      "description": "If true today button will be displayed. **Note** that clear button has higher priority",
       "name": "showTodayButton",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/MobileWrapper.tsx",
@@ -247,6 +247,21 @@
       "required": false,
       "type": {
         "name": "(date: DateIOType) => void"
+      }
+    },
+    "showDaysOutsideCurrentMonth": {
+      "defaultValue": {
+        "value": "false"
+      },
+      "description": "Display disabled dates outside the current month",
+      "name": "showDaysOutsideCurrentMonth",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
       }
     },
     "leftArrowIcon": {
@@ -443,7 +458,7 @@
     },
     "renderDay": {
       "defaultValue": null,
-      "description": "Custom renderer for day",
+      "description": "Custom renderer for day, check [DayComponentProps api](/api/Day)",
       "name": "renderDay",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -451,7 +466,7 @@
       },
       "required": false,
       "type": {
-        "name": "(day: DateIOType, selectedDate: DateIOType, dayInCurrentMonth: boolean, dayComponent: Element) => Element"
+        "name": "(day: DateIOType, selectedDate: DateIOType, DayComponentProps: DayProps) => Element"
       }
     },
     "allowKeyboardControl": {
@@ -765,19 +780,6 @@
       "required": false,
       "type": {
         "name": "string"
-      }
-    },
-    "labelFunc": {
-      "defaultValue": null,
-      "description": "Dynamic formatter of text field value",
-      "name": "labelFunc",
-      "parent": {
-        "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
-        "name": "DateInputProps"
-      },
-      "required": false,
-      "type": {
-        "name": "(date: DateIOType, invalidLabel: string) => string"
       }
     },
     "TextFieldComponent": {
@@ -1399,19 +1401,6 @@
         "name": "string"
       }
     },
-    "labelFunc": {
-      "defaultValue": null,
-      "description": "Dynamic formatter of text field value",
-      "name": "labelFunc",
-      "parent": {
-        "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
-        "name": "DateInputProps"
-      },
-      "required": false,
-      "type": {
-        "name": "(date: DateIOType, invalidLabel: string) => string"
-      }
-    },
     "TextFieldComponent": {
       "defaultValue": null,
       "description": "Override input component",
@@ -1867,19 +1856,6 @@
         "name": "string"
       }
     },
-    "labelFunc": {
-      "defaultValue": null,
-      "description": "Dynamic formatter of text field value",
-      "name": "labelFunc",
-      "parent": {
-        "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
-        "name": "DateInputProps"
-      },
-      "required": false,
-      "type": {
-        "name": "(date: DateIOType, invalidLabel: string) => string"
-      }
-    },
     "TextFieldComponent": {
       "defaultValue": null,
       "description": "Override input component",
@@ -2238,6 +2214,21 @@
         "name": "(date: DateIOType) => void"
       }
     },
+    "showDaysOutsideCurrentMonth": {
+      "defaultValue": {
+        "value": "false"
+      },
+      "description": "Display disabled dates outside the current month",
+      "name": "showDaysOutsideCurrentMonth",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
     "leftArrowIcon": {
       "defaultValue": null,
       "description": "Left arrow icon",
@@ -2432,7 +2423,7 @@
     },
     "renderDay": {
       "defaultValue": null,
-      "description": "Custom renderer for day",
+      "description": "Custom renderer for day, check [DayComponentProps api](/api/Day)",
       "name": "renderDay",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -2440,7 +2431,7 @@
       },
       "required": false,
       "type": {
-        "name": "(day: DateIOType, selectedDate: DateIOType, dayInCurrentMonth: boolean, dayComponent: Element) => Element"
+        "name": "(day: DateIOType, selectedDate: DateIOType, DayComponentProps: DayProps) => Element"
       }
     },
     "loadingIndicator": {
@@ -2542,7 +2533,7 @@
     },
     "renderDay": {
       "defaultValue": null,
-      "description": "Custom renderer for day",
+      "description": "Custom renderer for day, check [DayComponentProps api](/api/Day)",
       "name": "renderDay",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -2550,7 +2541,7 @@
       },
       "required": false,
       "type": {
-        "name": "(day: DateIOType, selectedDate: DateIOType, dayInCurrentMonth: boolean, dayComponent: Element) => Element"
+        "name": "(day: DateIOType, selectedDate: DateIOType, DayComponentProps: DayProps) => Element"
       }
     },
     "allowKeyboardControl": {
@@ -2579,6 +2570,180 @@
       "required": false,
       "type": {
         "name": "Element"
+      }
+    },
+    "showDaysOutsideCurrentMonth": {
+      "defaultValue": {
+        "value": "false"
+      },
+      "description": "Display disabled dates outside the current month",
+      "name": "showDaysOutsideCurrentMonth",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    }
+  },
+  "Day": {
+    "day": {
+      "defaultValue": null,
+      "description": "The date to show",
+      "name": "day",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": true,
+      "type": {
+        "name": "any"
+      }
+    },
+    "focused": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Is focused by keyboard navigation",
+      "name": "focused",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
+    "focusable": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Can be focused by tabbing in",
+      "name": "focusable",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
+    "isInCurrentMonth": {
+      "defaultValue": null,
+      "description": "Is day in current month",
+      "name": "isInCurrentMonth",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": true,
+      "type": {
+        "name": "boolean"
+      }
+    },
+    "isAnimating": {
+      "defaultValue": null,
+      "description": "Is switching month animation going on right now",
+      "name": "isAnimating",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
+    "isToday": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Is today?",
+      "name": "isToday",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
+    "disabled": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Disabled?",
+      "name": "disabled",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
+    "selected": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Selected?",
+      "name": "selected",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
+    "allowKeyboardControl": {
+      "defaultValue": null,
+      "description": "Is keyboard control and focus management enabled",
+      "name": "allowKeyboardControl",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
+    "disableMargin": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Disable margin between days, useful for displaying range of days",
+      "name": "disableMargin",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
+      }
+    },
+    "showDaysOutsideCurrentMonth": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Display disabled dates outside the current month",
+      "name": "showDaysOutsideCurrentMonth",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
+        "name": "DayProps"
+      },
+      "required": false,
+      "type": {
+        "name": "boolean"
       }
     }
   },

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -458,7 +458,7 @@
     },
     "renderDay": {
       "defaultValue": null,
-      "description": "Custom renderer for day, check [DayComponentProps api](/api/Day)",
+      "description": "Custom renderer for day. Check [DayComponentProps api](https://material-ui-pickers.dev/api/Day)",
       "name": "renderDay",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -2423,7 +2423,7 @@
     },
     "renderDay": {
       "defaultValue": null,
-      "description": "Custom renderer for day, check [DayComponentProps api](/api/Day)",
+      "description": "Custom renderer for day. Check [DayComponentProps api](https://material-ui-pickers.dev/api/Day)",
       "name": "renderDay",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -2533,7 +2533,7 @@
     },
     "renderDay": {
       "defaultValue": null,
-      "description": "Custom renderer for day, check [DayComponentProps api](/api/Day)",
+      "description": "Custom renderer for day. Check [DayComponentProps api](https://material-ui-pickers.dev/api/Day)",
       "name": "renderDay",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -754,12 +754,12 @@
         "name": "ComponentClass<ToolbarComponentProps<any>, any> | FunctionComponent<ToolbarComponentProps<any>>"
       }
     },
-    "title": {
+    "toolbarTitle": {
       "defaultValue": {
         "value": "\"SELECT DATE\""
       },
       "description": "Mobile picker title, displaying in the toolbar",
-      "name": "title",
+      "name": "toolbarTitle",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
         "name": "BasePickerProps"
@@ -1373,12 +1373,12 @@
         "name": "ComponentClass<ToolbarComponentProps<any>, any> | FunctionComponent<ToolbarComponentProps<any>>"
       }
     },
-    "title": {
+    "toolbarTitle": {
       "defaultValue": {
         "value": "\"SELECT DATE\""
       },
       "description": "Mobile picker title, displaying in the toolbar",
-      "name": "title",
+      "name": "toolbarTitle",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
         "name": "BasePickerProps"
@@ -1828,12 +1828,12 @@
         "name": "ComponentClass<ToolbarComponentProps<any>, any> | FunctionComponent<ToolbarComponentProps<any>>"
       }
     },
-    "title": {
+    "toolbarTitle": {
       "defaultValue": {
         "value": "\"SELECT DATE\""
       },
       "description": "Mobile picker title, displaying in the toolbar",
-      "name": "title",
+      "name": "toolbarTitle",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
         "name": "BasePickerProps"

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -622,10 +622,10 @@
         "name": "boolean"
       }
     },
-    "initialFocusedDate": {
+    "defaultHighlight": {
       "defaultValue": null,
       "description": "Date that will be initially highlighted if null was passed",
-      "name": "initialFocusedDate",
+      "name": "defaultHighlight",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
         "name": "BasePickerProps"
@@ -1241,10 +1241,10 @@
         "name": "boolean"
       }
     },
-    "initialFocusedDate": {
+    "defaultHighlight": {
       "defaultValue": null,
       "description": "Date that will be initially highlighted if null was passed",
-      "name": "initialFocusedDate",
+      "name": "defaultHighlight",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
         "name": "BasePickerProps"
@@ -1696,10 +1696,10 @@
         "name": "boolean"
       }
     },
-    "initialFocusedDate": {
+    "defaultHighlight": {
       "defaultValue": null,
       "description": "Date that will be initially highlighted if null was passed",
-      "name": "initialFocusedDate",
+      "name": "defaultHighlight",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
         "name": "BasePickerProps"

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -249,6 +249,19 @@
         "name": "(date: DateIOType) => void"
       }
     },
+    "toolbarFormat": {
+      "defaultValue": null,
+      "description": "Date format, that is displaying in toolbar",
+      "name": "toolbarFormat",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/DatePicker/DatePicker.tsx",
+        "name": "BaseDatePickerProps"
+      },
+      "required": false,
+      "type": {
+        "name": "string"
+      }
+    },
     "disableHighlightToday": {
       "defaultValue": {
         "value": "false"
@@ -2102,6 +2115,19 @@
       "required": false,
       "type": {
         "name": "ParsableDate"
+      }
+    },
+    "toolbarFormat": {
+      "defaultValue": null,
+      "description": "Date format, that is displaying in toolbar",
+      "name": "toolbarFormat",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/DateTimePicker/DateTimePicker.tsx",
+        "name": "DateTimePickerViewsProps"
+      },
+      "required": false,
+      "type": {
+        "name": "string"
       }
     },
     "ampm": {

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -823,12 +823,12 @@
         "name": "ComponentClass<TextFieldProps, any> | FunctionComponent<TextFieldProps>"
       }
     },
-    "emptyLabel": {
+    "emptyInputText": {
       "defaultValue": {
         "value": "' '"
       },
       "description": "Message displaying in read-only text field when null passed",
-      "name": "emptyLabel",
+      "name": "emptyInputText",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"
@@ -1427,12 +1427,12 @@
         "name": "ComponentClass<TextFieldProps, any> | FunctionComponent<TextFieldProps>"
       }
     },
-    "emptyLabel": {
+    "emptyInputText": {
       "defaultValue": {
         "value": "' '"
       },
       "description": "Message displaying in read-only text field when null passed",
-      "name": "emptyLabel",
+      "name": "emptyInputText",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"
@@ -1867,12 +1867,12 @@
         "name": "ComponentClass<TextFieldProps, any> | FunctionComponent<TextFieldProps>"
       }
     },
-    "emptyLabel": {
+    "emptyInputText": {
       "defaultValue": {
         "value": "' '"
       },
       "description": "Message displaying in read-only text field when null passed",
-      "name": "emptyLabel",
+      "name": "emptyInputText",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"

--- a/docs/scripts/docgen.js
+++ b/docs/scripts/docgen.js
@@ -32,6 +32,7 @@ const components = [
   'DateTimePicker/KeyboardDateTimePicker.tsx',
   // internal components
   'views/Calendar/Calendar.tsx',
+  'views/Calendar/Day.tsx',
   'views/Clock/ClockView.tsx',
 ];
 

--- a/docs/utils/helpers.ts
+++ b/docs/utils/helpers.ts
@@ -23,7 +23,7 @@ export function makeJSDateObject(date: Date | Moment | DateTime | Dayjs) {
     return new Date(date.getTime());
   }
 
-  return date as any // handle case with invalid input
+  return date as any; // handle case with invalid input
 }
 
 export function copy(text: string) {

--- a/docs/utils/helpers.ts
+++ b/docs/utils/helpers.ts
@@ -23,7 +23,7 @@ export function makeJSDateObject(date: Date | Moment | DateTime | Dayjs) {
     return new Date(date.getTime());
   }
 
-  throw new Error('Cannot properly parse argument passed to cloneCrossUtils');
+  return date as any // handle case with invalid input
 }
 
 export function copy(text: string) {

--- a/lib/.size-snapshot.json
+++ b/lib/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "build/dist/material-ui-pickers.esm.js": {
-    "bundled": 135428,
-    "minified": 74551,
-    "gzipped": 20145,
+    "bundled": 142460,
+    "minified": 78059,
+    "gzipped": 20972,
     "treeshaked": {
       "rollup": {
-        "code": 61430,
-        "import_statements": 2049
+        "code": 64546,
+        "import_statements": 2099
       },
       "webpack": {
-        "code": 68708
+        "code": 71967
       }
     }
   },
   "build/dist/material-ui-pickers.umd.js": {
-    "bundled": 589372,
-    "minified": 218831,
-    "gzipped": 44808
+    "bundled": 596625,
+    "minified": 222008,
+    "gzipped": 45597
   },
   "build/dist/material-ui-pickers.umd.min.js": {
-    "bundled": 529199,
-    "minified": 200373,
-    "gzipped": 39904
+    "bundled": 536375,
+    "minified": 203506,
+    "gzipped": 40803
   }
 }

--- a/lib/src/DatePicker/DatePicker.tsx
+++ b/lib/src/DatePicker/DatePicker.tsx
@@ -33,7 +33,7 @@ const datePickerConfig = {
       views,
       openTo,
       mask: '__/__/____',
-      format: getFormatByViews(views, utils),
+      inputFormat: getFormatByViews(views, utils),
     };
   },
 };

--- a/lib/src/DatePicker/DatePicker.tsx
+++ b/lib/src/DatePicker/DatePicker.tsx
@@ -17,6 +17,8 @@ export type DatePickerView = 'year' | 'date' | 'month';
 export interface BaseDatePickerProps extends ExportedCalendarViewProps {
   /** Callback firing on year change @DateIOType */
   onYearChange?: (date: MaterialUiPickersDate) => void;
+  /** Date format, that is displaying in toolbar */
+  toolbarFormat?: string;
 }
 
 export type DatePickerProps = BaseDatePickerProps &

--- a/lib/src/DatePicker/DatePickerToolbar.tsx
+++ b/lib/src/DatePicker/DatePickerToolbar.tsx
@@ -64,6 +64,7 @@ export const DatePickerToolbar: React.FC<ToolbarComponentProps> = ({
       <Typography
         variant="h4"
         children={dateText}
+        data-mui-test="datepicker-toolbar-date"
         align={isLandscape ? 'left' : 'center'}
         className={clsx({ [classes.dateTitleLandscape]: isLandscape })}
       />

--- a/lib/src/DatePicker/DatePickerToolbar.tsx
+++ b/lib/src/DatePicker/DatePickerToolbar.tsx
@@ -26,7 +26,7 @@ export const DatePickerToolbar: React.FC<ToolbarComponentProps> = ({
   isLandscape,
   isMobileKeyboardViewOpen,
   toggleMobileKeyboardView,
-  title = 'SELECT DATE',
+  toolbarTitle = 'SELECT DATE',
 }) => {
   const utils = useUtils();
   const classes = useStyles();
@@ -50,7 +50,7 @@ export const DatePickerToolbar: React.FC<ToolbarComponentProps> = ({
 
   return (
     <PickerToolbar
-      title={title}
+      toolbarTitle={toolbarTitle}
       isMobileKeyboardViewOpen={isMobileKeyboardViewOpen}
       toggleMobileKeyboardView={toggleMobileKeyboardView}
       isLandscape={isLandscape}

--- a/lib/src/DatePicker/DatePickerToolbar.tsx
+++ b/lib/src/DatePicker/DatePickerToolbar.tsx
@@ -26,12 +26,17 @@ export const DatePickerToolbar: React.FC<ToolbarComponentProps> = ({
   isLandscape,
   isMobileKeyboardViewOpen,
   toggleMobileKeyboardView,
+  toolbarFormat,
   toolbarTitle = 'SELECT DATE',
 }) => {
   const utils = useUtils();
   const classes = useStyles();
 
   const dateText = React.useMemo(() => {
+    if (toolbarFormat) {
+      return utils.formatByString(date, toolbarFormat);
+    }
+
     if (isYearOnlyView(views as DatePickerView[])) {
       return utils.format(date, 'year');
     }
@@ -46,7 +51,7 @@ export const DatePickerToolbar: React.FC<ToolbarComponentProps> = ({
     return /en/.test(utils.getCurrentLocaleCode())
       ? utils.format(date, 'normalDateWithWeekday')
       : utils.format(date, 'normalDate');
-  }, [date, utils, views]);
+  }, [date, toolbarFormat, utils, views]);
 
   return (
     <PickerToolbar

--- a/lib/src/DateTimePicker/DateTimePicker.tsx
+++ b/lib/src/DateTimePicker/DateTimePicker.tsx
@@ -35,8 +35,8 @@ export type DateTimePickerProps = WithDateInputProps &
 
 function useDefaultProps({
   ampm,
-  format,
   mask,
+  inputFormat,
   maxDateTime,
   minDateTime,
   orientation = 'portrait',
@@ -66,7 +66,7 @@ function useDefaultProps({
     disableTimeValidationIgnoreDatePart: Boolean(minDateTime || maxDateTime),
     acceptRegex: willUseAmPm ? /[\dap]/gi : /\d/gi,
     mask: mask || willUseAmPm ? '__/__/____ __:__ _M' : '__/__/____ __:__',
-    format: pick12hOr24hFormat(format, ampm, {
+    inputFormat: pick12hOr24hFormat(inputFormat, ampm, {
       localized: utils.formats.keyboardDateTime,
       '12h': utils.formats.keyboardDateTime12h,
       '24h': utils.formats.keyboardDateTime24h,

--- a/lib/src/DateTimePicker/DateTimePicker.tsx
+++ b/lib/src/DateTimePicker/DateTimePicker.tsx
@@ -27,6 +27,8 @@ export interface DateTimePickerViewsProps extends BaseDateTimePickerProps {
   minDateTime?: ParsableDate;
   /** Minimal selectable moment of time with binding to date, to set max time in each day use `maxTime` */
   maxDateTime?: ParsableDate;
+  /** Date format, that is displaying in toolbar */
+  toolbarFormat?: string;
 }
 
 export type DateTimePickerProps = WithDateInputProps &

--- a/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -45,6 +45,7 @@ export const DateTimePickerToolbar: React.FC<ToolbarComponentProps> = ({
   hideTabs,
   dateRangeIcon,
   timeIcon,
+  toolbarFormat,
   isMobileKeyboardViewOpen,
   toggleMobileKeyboardView,
   toolbarTitle = 'SELECT DATE & TIME',
@@ -77,7 +78,11 @@ export const DateTimePickerToolbar: React.FC<ToolbarComponentProps> = ({
             variant="h4"
             onClick={() => setOpenView('date')}
             selected={openView === 'date'}
-            label={utils.format(date, 'shortDate')}
+            label={
+              toolbarFormat
+                ? utils.formatByString(date, toolbarFormat)
+                : utils.format(date, 'shortDate')
+            }
           />
         </div>
 

--- a/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -47,7 +47,7 @@ export const DateTimePickerToolbar: React.FC<ToolbarComponentProps> = ({
   timeIcon,
   isMobileKeyboardViewOpen,
   toggleMobileKeyboardView,
-  title = 'SELECT DATE & TIME',
+  toolbarTitle = 'SELECT DATE & TIME',
 }) => {
   const utils = useUtils();
   const classes = useStyles();
@@ -56,7 +56,7 @@ export const DateTimePickerToolbar: React.FC<ToolbarComponentProps> = ({
   return (
     <>
       <PickerToolbar
-        title={title}
+        toolbarTitle={toolbarTitle}
         isLandscape={false}
         penIconClassName={classes.penIcon}
         className={classes.toolbar}

--- a/lib/src/Picker/Picker.tsx
+++ b/lib/src/Picker/Picker.tsx
@@ -25,7 +25,7 @@ export type ToolbarComponentProps<T extends PickerView = any> = BaseDatePickerPr
     date: MaterialUiPickersDate;
     setOpenView: (view: T) => void;
     onChange: (date: MaterialUiPickersDate, isFinish?: boolean) => void;
-    title?: string;
+    toolbarTitle?: string;
     // TODO move out, cause it is DateTimePickerOnly
     hideTabs?: boolean;
     dateRangeIcon?: React.ReactNode;
@@ -42,7 +42,7 @@ export interface PickerViewProps<TView extends PickerView>
     WithViewsProps<TView>,
     BaseDatePickerProps,
     ExportedClockViewProps {
-  title?: string;
+  toolbarTitle?: string;
   showToolbar?: boolean;
   ToolbarComponent: React.ComponentType<ToolbarComponentProps<any>>;
   // TODO move out, cause it is DateTimePickerOnly
@@ -94,7 +94,7 @@ export function Picker({
   date,
   openTo = 'date',
   views = ['year', 'month', 'date', 'hours', 'minutes', 'seconds'],
-  title,
+  toolbarTitle,
   showToolbar,
   onDateChange,
   ToolbarComponent,
@@ -140,7 +140,7 @@ export function Picker({
           onChange={onChange}
           setOpenView={setOpenView}
           openView={openView}
-          title={title}
+          toolbarTitle={toolbarTitle}
           ampmInClock={other.ampmInClock}
           isMobileKeyboardViewOpen={isMobileKeyboardViewOpen}
           toggleMobileKeyboardView={toggleMobileKeyboardView}

--- a/lib/src/Picker/makePickerWithState.tsx
+++ b/lib/src/Picker/makePickerWithState.tsx
@@ -49,7 +49,7 @@ export function makePickerWithStateAndWrapper<
       showToolbar,
       inputFormat,
       hideTabs,
-      initialFocusedDate,
+      defaultHighlight,
       leftArrowButtonProps,
       leftArrowIcon,
       loadingIndicator,

--- a/lib/src/Picker/makePickerWithState.tsx
+++ b/lib/src/Picker/makePickerWithState.tsx
@@ -74,7 +74,7 @@ export function makePickerWithStateAndWrapper<
       ToolbarComponent = DefaultToolbarComponent,
       value,
       views,
-      title,
+      toolbarTitle,
       invalidDateMessage,
       minDateMessage,
       wider,
@@ -115,7 +115,8 @@ export function makePickerWithStateAndWrapper<
         <Picker
           {...pickerProps}
           DateInputProps={{ ...inputProps, ...restPropsForTextField }}
-          title={title}
+          // @ts-ignore
+          toolbarTitle={toolbarTitle || restPropsForTextField.label}
           allowKeyboardControl={allowKeyboardControl}
           ampm={ampm}
           ampmInClock={ampmInClock}

--- a/lib/src/Picker/makePickerWithState.tsx
+++ b/lib/src/Picker/makePickerWithState.tsx
@@ -82,6 +82,7 @@ export function makePickerWithStateAndWrapper<
       maxDateMessage,
       disableTimeValidationIgnoreDatePart,
       showDaysOutsideCurrentMonth,
+      disableHighlightToday,
       // WrapperProps
       clearable,
       clearLabel,
@@ -116,22 +117,22 @@ export function makePickerWithStateAndWrapper<
           {...pickerProps}
           DateInputProps={{ ...inputProps, ...restPropsForTextField }}
           // @ts-ignore
-          toolbarTitle={toolbarTitle || restPropsForTextField.label}
           allowKeyboardControl={allowKeyboardControl}
           ampm={ampm}
           ampmInClock={ampmInClock}
           dateRangeIcon={dateRangeIcon}
           disableFuture={disableFuture}
+          disableHighlightToday={disableHighlightToday}
           disablePast={disablePast}
-          showToolbar={showToolbar}
+          disableTimeValidationIgnoreDatePart={disableTimeValidationIgnoreDatePart}
           hideTabs={hideTabs}
           leftArrowButtonProps={leftArrowButtonProps}
           leftArrowIcon={leftArrowIcon}
           loadingIndicator={loadingIndicator}
           maxDate={maxDate}
+          maxTime={maxTime}
           minDate={minDate}
           minTime={minTime}
-          maxTime={maxTime}
           minutesStep={minutesStep}
           onMonthChange={onMonthChange}
           onYearChange={onYearChange}
@@ -142,12 +143,13 @@ export function makePickerWithStateAndWrapper<
           rightArrowIcon={rightArrowIcon}
           shouldDisableDate={shouldDisableDate}
           shouldDisableTime={shouldDisableTime}
+          showDaysOutsideCurrentMonth={showDaysOutsideCurrentMonth}
+          showToolbar={showToolbar}
           strictCompareDates={strictCompareDates}
           timeIcon={timeIcon}
           ToolbarComponent={ToolbarComponent}
+          toolbarTitle={toolbarTitle || restPropsForTextField.label}
           views={views}
-          showDaysOutsideCurrentMonth={showDaysOutsideCurrentMonth}
-          disableTimeValidationIgnoreDatePart={disableTimeValidationIgnoreDatePart}
         />
       </WrapperComponent>
     );

--- a/lib/src/Picker/makePickerWithState.tsx
+++ b/lib/src/Picker/makePickerWithState.tsx
@@ -21,7 +21,7 @@ export interface WithViewsProps<T extends DateTimePickerView> {
 export type WithDateInputProps = DateValidationProps & BasePickerProps & ExportedDateInputProps;
 
 export interface MakePickerOptions<T extends unknown> {
-  useDefaultProps: (props: T) => Partial<T> & { format: string };
+  useDefaultProps: (props: T) => Partial<T> & { inputFormat?: string };
   DefaultToolbarComponent: React.ComponentType<ToolbarComponentProps>;
 }
 
@@ -47,7 +47,7 @@ export function makePickerWithStateAndWrapper<
       disableFuture,
       disablePast,
       showToolbar,
-      format,
+      inputFormat,
       hideTabs,
       initialFocusedDate,
       leftArrowButtonProps,

--- a/lib/src/Picker/makePickerWithState.tsx
+++ b/lib/src/Picker/makePickerWithState.tsx
@@ -148,6 +148,7 @@ export function makePickerWithStateAndWrapper<
           strictCompareDates={strictCompareDates}
           timeIcon={timeIcon}
           ToolbarComponent={ToolbarComponent}
+          // @ts-ignore
           toolbarTitle={toolbarTitle || restPropsForTextField.label}
           views={views}
         />

--- a/lib/src/Picker/makePickerWithState.tsx
+++ b/lib/src/Picker/makePickerWithState.tsx
@@ -71,6 +71,7 @@ export function makePickerWithStateAndWrapper<
       shouldDisableTime,
       strictCompareDates,
       timeIcon,
+      toolbarFormat,
       ToolbarComponent = DefaultToolbarComponent,
       value,
       views,
@@ -147,6 +148,7 @@ export function makePickerWithStateAndWrapper<
           showToolbar={showToolbar}
           strictCompareDates={strictCompareDates}
           timeIcon={timeIcon}
+          toolbarFormat={toolbarFormat}
           ToolbarComponent={ToolbarComponent}
           // @ts-ignore
           toolbarTitle={toolbarTitle || restPropsForTextField.label}

--- a/lib/src/Picker/makePickerWithState.tsx
+++ b/lib/src/Picker/makePickerWithState.tsx
@@ -81,6 +81,7 @@ export function makePickerWithStateAndWrapper<
       showTabs,
       maxDateMessage,
       disableTimeValidationIgnoreDatePart,
+      showDaysOutsideCurrentMonth,
       // WrapperProps
       clearable,
       clearLabel,
@@ -144,6 +145,7 @@ export function makePickerWithStateAndWrapper<
           timeIcon={timeIcon}
           ToolbarComponent={ToolbarComponent}
           views={views}
+          showDaysOutsideCurrentMonth={showDaysOutsideCurrentMonth}
           disableTimeValidationIgnoreDatePart={disableTimeValidationIgnoreDatePart}
         />
       </WrapperComponent>

--- a/lib/src/TimePicker/TimePicker.tsx
+++ b/lib/src/TimePicker/TimePicker.tsx
@@ -26,8 +26,8 @@ export function getTextFieldAriaText(value: ParsableDate, utils: MuiPickersUtils
 
 function useDefaultProps({
   ampm,
-  format,
   mask,
+  inputFormat,
   openTo = 'hours',
   views = ['hours', 'minutes'],
 }: TimePickerProps) {
@@ -43,7 +43,7 @@ function useDefaultProps({
     mask: mask || willUseAmPm ? '__:__ _M' : '__:__',
     getOpenDialogAriaText: getTextFieldAriaText,
     keyboardIcon: <ClockIcon />,
-    format: pick12hOr24hFormat(format, ampm, {
+    inputFormat: pick12hOr24hFormat(inputFormat, ampm, {
       localized: utils.formats.fullTime,
       '12h': utils.formats.fullTime12h,
       '24h': utils.formats.fullTime24h,

--- a/lib/src/TimePicker/TimePickerToolbar.tsx
+++ b/lib/src/TimePicker/TimePickerToolbar.tsx
@@ -82,7 +82,7 @@ export const TimePickerToolbar: React.FC<ToolbarComponentProps> = ({
   ampmInClock,
   isMobileKeyboardViewOpen,
   toggleMobileKeyboardView,
-  title = 'SELECT TIME',
+  toolbarTitle = 'SELECT TIME',
 }) => {
   const utils = useUtils();
   const theme = useTheme();
@@ -103,7 +103,7 @@ export const TimePickerToolbar: React.FC<ToolbarComponentProps> = ({
   return (
     <PickerToolbar
       landscapeDirection="row"
-      title={title}
+      toolbarTitle={toolbarTitle}
       isLandscape={isLandscape}
       isMobileKeyboardViewOpen={isMobileKeyboardViewOpen}
       toggleMobileKeyboardView={toggleMobileKeyboardView}

--- a/lib/src/__tests__/e2e/DatePicker.test.tsx
+++ b/lib/src/__tests__/e2e/DatePicker.test.tsx
@@ -209,6 +209,7 @@ test('Custom toolbar component', () => {
   const component = mount(
     <MobileDatePicker
       open
+      disableHighlightToday
       inputProps={{}}
       value={new Date()}
       onChange={jest.fn()}

--- a/lib/src/__tests__/e2e/DatePickerProps.test.tsx
+++ b/lib/src/__tests__/e2e/DatePickerProps.test.tsx
@@ -44,4 +44,17 @@ describe('DatePicker - different props', () => {
       'Default label'
     );
   });
+
+  it('toolbarFormat – should format toolbar according to passed format', () => {
+    const component = mount(
+      <MobileDatePicker
+        open
+        onChange={jest.fn()}
+        toolbarFormat="MMMM"
+        value={utilsToUse.date('2018-01-01T00:00:00.000Z')}
+      />
+    );
+
+    expect(component.find('h4[data-mui-test="datepicker-toolbar-date"]').text()).toBe('January');
+  });
 });

--- a/lib/src/__tests__/e2e/DatePickerProps.test.tsx
+++ b/lib/src/__tests__/e2e/DatePickerProps.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { mount, utilsToUse } from '../test-utils';
-import { DatePicker } from '../../DatePicker/DatePicker';
+import { DatePicker, MobileDatePicker } from '../../DatePicker/DatePicker';
 
 describe('DatePicker - different props', () => {
   it('Should not render toolbar if onlyCalendar = true', () => {
@@ -14,5 +14,34 @@ describe('DatePicker - different props', () => {
     );
 
     expect(component.find('WithStyles(PickerToolbar)').length).toBe(0);
+  });
+
+  it('toolbarTitle – should render value from prop', () => {
+    const component = mount(
+      <MobileDatePicker
+        open
+        toolbarTitle="test"
+        label="something"
+        onChange={jest.fn()}
+        value={utilsToUse.date('2018-01-01T00:00:00.000Z')}
+      />
+    );
+
+    expect(component.find('span[data-mui-test="picker-toolbar-title"]').text()).toBe('test');
+  });
+
+  it('toolbarTitle – should use label if no toolbar title', () => {
+    const component = mount(
+      <MobileDatePicker
+        open
+        label="Default label"
+        onChange={jest.fn()}
+        value={utilsToUse.date('2018-01-01T00:00:00.000Z')}
+      />
+    );
+
+    expect(component.find('span[data-mui-test="picker-toolbar-title"]').text()).toBe(
+      'Default label'
+    );
   });
 });

--- a/lib/src/__tests__/e2e/DateTimePicker.test.tsx
+++ b/lib/src/__tests__/e2e/DateTimePicker.test.tsx
@@ -15,7 +15,7 @@ describe('e2e - DateTimePicker', () => {
     component = mount(
       <DateTimePicker
         clearable
-        format={format}
+        inputFormat={format}
         onClose={onCloseMock}
         onChange={onChangeMock}
         value={utilsToUse.date('2018-01-01T00:00:00.000Z')}

--- a/lib/src/__tests__/e2e/KeyboardDatePicker.test.tsx
+++ b/lib/src/__tests__/e2e/KeyboardDatePicker.test.tsx
@@ -13,7 +13,7 @@ describe('e2e -- DatePicker keyboard input', () => {
       <DesktopDatePicker
         label="Masked input"
         placeholder="10/10/2018"
-        format={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
+        inputFormat={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
         value={new Date('2018-01-01T00:00:00.000Z')}
         onChange={onChangeMock}
         InputAdornmentProps={{
@@ -41,7 +41,7 @@ describe('e2e -- KeyboardDatePicker validation errors', () => {
   it('Should render error message if date is unparseable', () => {
     const component = mount(
       <DesktopDatePicker
-        format={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
+        inputFormat={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
         value={new Date(NaN)}
         onChange={jest.fn()}
       />
@@ -56,7 +56,7 @@ describe('e2e -- KeyboardDatePicker validation errors', () => {
         onChange={jest.fn()}
         disableFuture
         value={addDays(new Date(), 2)}
-        format={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
+        inputFormat={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
       />
     );
 
@@ -71,7 +71,7 @@ describe('e2e -- KeyboardDatePicker validation errors', () => {
         onChange={jest.fn()}
         disablePast
         value={addDays(new Date(), -2)}
-        format={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
+        inputFormat={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
       />
     );
 
@@ -86,7 +86,7 @@ describe('e2e -- KeyboardDatePicker validation errors', () => {
         onChange={jest.fn()}
         maxDate={new Date('2018-01-01T00:00:00.000Z')}
         value={new Date('2018-01-01T01:00:00.000Z')}
-        format={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
+        inputFormat={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
       />
     );
 
@@ -100,7 +100,7 @@ describe('e2e -- KeyboardDatePicker validation errors', () => {
         maxDate={new Date('2018-01-01T00:00:00.000Z')}
         value={new Date('2018-01-01T01:00:00.000Z')}
         strictCompareDates
-        format={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
+        inputFormat={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
       />
     );
 
@@ -115,7 +115,7 @@ describe('e2e -- KeyboardDatePicker validation errors', () => {
         onChange={jest.fn()}
         minDate={new Date('2018-01-01T01:00:00.000Z')}
         value={new Date('2018-01-01T00:00:00.000Z')}
-        format={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
+        inputFormat={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
       />
     );
 
@@ -129,7 +129,7 @@ describe('e2e -- KeyboardDatePicker validation errors', () => {
         minDate={new Date('2018-01-01T01:00:00.000Z')}
         value={new Date('2018-01-01T00:00:00.000Z')}
         strictCompareDates
-        format={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
+        inputFormat={process.env.UTILS === 'moment' ? 'DD/MM/YYYY' : 'dd/MM/yyyy'}
       />
     );
 

--- a/lib/src/__tests__/e2e/KeyboardDateTimePicker.test.tsx
+++ b/lib/src/__tests__/e2e/KeyboardDateTimePicker.test.tsx
@@ -20,7 +20,7 @@ describe('e2e - DesktopDateTimePicker', () => {
         onChange={onChangeMock}
         onClose={onCloseMock}
         onOpen={onOpenMock}
-        format={format}
+        inputFormat={format}
         KeyboardButtonProps={{ id: 'keyboard-button' }}
         value={utilsToUse.date('2018-01-01T00:00:00.000Z')}
       />

--- a/lib/src/_helpers/text-field-helper.ts
+++ b/lib/src/_helpers/text-field-helper.ts
@@ -13,11 +13,7 @@ export function getTextFieldAriaText(rawValue: ParsableDate, utils: MuiPickersUt
 export const getDisplayDate = (
   value: ParsableDate,
   utils: MuiPickersUtils,
-  {
-    inputFormat,
-    invalidLabel = '',
-    emptyLabel,
-  }: Pick<DateInputProps, 'inputFormat' | 'invalidLabel' | 'emptyLabel'>
+  { inputFormat, emptyLabel }: Pick<DateInputProps, 'inputFormat' | 'emptyLabel'>
 ) => {
   const date = utils.date(value);
   const isEmpty = value === null;
@@ -26,7 +22,7 @@ export const getDisplayDate = (
     return emptyLabel || '';
   }
 
-  return utils.isValid(date) ? utils.formatByString(date, inputFormat) : invalidLabel;
+  return utils.isValid(date) ? utils.formatByString(date, inputFormat) : '';
 };
 
 export interface BaseValidationProps {

--- a/lib/src/_helpers/text-field-helper.ts
+++ b/lib/src/_helpers/text-field-helper.ts
@@ -17,15 +17,10 @@ export const getDisplayDate = (
     inputFormat,
     invalidLabel = '',
     emptyLabel,
-    labelFunc,
-  }: Pick<DateInputProps, 'inputFormat' | 'invalidLabel' | 'emptyLabel' | 'labelFunc'>
+  }: Pick<DateInputProps, 'inputFormat' | 'invalidLabel' | 'emptyLabel'>
 ) => {
   const date = utils.date(value);
   const isEmpty = value === null;
-
-  if (labelFunc) {
-    return labelFunc(isEmpty ? null : date, invalidLabel!);
-  }
 
   if (isEmpty) {
     return emptyLabel || '';

--- a/lib/src/_helpers/text-field-helper.ts
+++ b/lib/src/_helpers/text-field-helper.ts
@@ -14,11 +14,11 @@ export const getDisplayDate = (
   value: ParsableDate,
   utils: MuiPickersUtils,
   {
-    format,
+    inputFormat,
     invalidLabel = '',
     emptyLabel,
     labelFunc,
-  }: Pick<DateInputProps, 'format' | 'invalidLabel' | 'emptyLabel' | 'labelFunc'>
+  }: Pick<DateInputProps, 'inputFormat' | 'invalidLabel' | 'emptyLabel' | 'labelFunc'>
 ) => {
   const date = utils.date(value);
   const isEmpty = value === null;
@@ -31,7 +31,7 @@ export const getDisplayDate = (
     return emptyLabel || '';
   }
 
-  return utils.isValid(date) ? utils.formatByString(date, format) : invalidLabel;
+  return utils.isValid(date) ? utils.formatByString(date, inputFormat) : invalidLabel;
 };
 
 export interface BaseValidationProps {

--- a/lib/src/_helpers/text-field-helper.ts
+++ b/lib/src/_helpers/text-field-helper.ts
@@ -13,13 +13,13 @@ export function getTextFieldAriaText(rawValue: ParsableDate, utils: MuiPickersUt
 export const getDisplayDate = (
   value: ParsableDate,
   utils: MuiPickersUtils,
-  { inputFormat, emptyLabel }: Pick<DateInputProps, 'inputFormat' | 'emptyLabel'>
+  { inputFormat, emptyInputText }: Pick<DateInputProps, 'inputFormat' | 'emptyInputText'>
 ) => {
   const date = utils.date(value);
   const isEmpty = value === null;
 
   if (isEmpty) {
-    return emptyLabel || '';
+    return emptyInputText || '';
   }
 
   return utils.isValid(date) ? utils.formatByString(date, inputFormat) : '';

--- a/lib/src/_shared/ArrowSwitcher.tsx
+++ b/lib/src/_shared/ArrowSwitcher.tsx
@@ -25,8 +25,7 @@ export interface ExportedArrowSwitcherProps {
   rightArrowButtonProps?: Partial<IconButtonProps>;
 }
 
-interface ArrowSwitcherProps extends ExportedArrowSwitcherProps {
-  className?: string;
+interface ArrowSwitcherProps extends ExportedArrowSwitcherProps, React.HTMLProps<HTMLDivElement> {
   isLeftDisabled: boolean;
   isRightDisabled: boolean;
   onLeftClick: () => void;
@@ -55,13 +54,14 @@ export const ArrowSwitcher: React.FC<ArrowSwitcherProps> = ({
   onRightClick,
   leftArrowIcon = <ArrowLeftIcon />,
   rightArrowIcon = <ArrowRightIcon />,
+  ...other
 }) => {
   const classes = useStyles();
   const theme = useTheme();
   const isRtl = theme.direction === 'rtl';
 
   return (
-    <div className={className}>
+    <div className={className} {...other}>
       <IconButton
         data-mui-test="previous-arrow-button"
         size="small"

--- a/lib/src/_shared/KeyboardDateInput.tsx
+++ b/lib/src/_shared/KeyboardDateInput.tsx
@@ -34,7 +34,6 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
   variant,
   emptyLabel,
   invalidLabel,
-  labelFunc,
   hideOpenPickerButton,
   ignoreInvalidInputs,
   onFocus,
@@ -49,7 +48,6 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
       inputFormat,
       emptyLabel,
       invalidLabel,
-      labelFunc,
     });
 
   const [innerInputValue, setInnerInputValue] = React.useState<string | null>(getInputValue());

--- a/lib/src/_shared/KeyboardDateInput.tsx
+++ b/lib/src/_shared/KeyboardDateInput.tsx
@@ -26,7 +26,7 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
   mask,
   maskChar = '_',
   acceptRegex = /[\d]/gi,
-  format,
+  inputFormat,
   disabled,
   rifmFormatter,
   TextFieldComponent = TextField,
@@ -46,7 +46,7 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
   const [isFocused, setIsFocused] = React.useState(false);
   const getInputValue = () =>
     getDisplayDate(rawValue, utils, {
-      format,
+      inputFormat,
       emptyLabel,
       invalidLabel,
       labelFunc,
@@ -58,12 +58,12 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
     if (!mask || disableMaskedInput) {
       return {
         isMaskValid: false,
-        placeholder: utils.formatByString(staticDateWith2DigitTokens, format),
+        placeholder: utils.formatByString(staticDateWith2DigitTokens, inputFormat),
       };
     }
 
-    return checkMaskIsValidForCurrentFormat(mask, maskChar, format, acceptRegex, utils);
-  }, [format, mask]); // eslint-disable-line
+    return checkMaskIsValidForCurrentFormat(mask, maskChar, inputFormat, acceptRegex, utils);
+  }, [inputFormat, mask]); // eslint-disable-line
 
   // prettier-ignore
   const formatter = React.useMemo(
@@ -85,7 +85,7 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
     const finalString = text === '' || text === mask ? null : text;
     setInnerInputValue(finalString);
 
-    const date = finalString === null ? null : utils.parse(finalString, format);
+    const date = finalString === null ? null : utils.parse(finalString, inputFormat);
     if (ignoreInvalidInputs && !utils.isValid(date)) {
       return;
     }

--- a/lib/src/_shared/KeyboardDateInput.tsx
+++ b/lib/src/_shared/KeyboardDateInput.tsx
@@ -33,7 +33,6 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
   keyboardIcon = <KeyboardIcon />,
   variant,
   emptyLabel,
-  invalidLabel,
   hideOpenPickerButton,
   ignoreInvalidInputs,
   onFocus,
@@ -47,7 +46,6 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
     getDisplayDate(rawValue, utils, {
       inputFormat,
       emptyLabel,
-      invalidLabel,
     });
 
   const [innerInputValue, setInnerInputValue] = React.useState<string | null>(getInputValue());

--- a/lib/src/_shared/KeyboardDateInput.tsx
+++ b/lib/src/_shared/KeyboardDateInput.tsx
@@ -32,7 +32,7 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
   TextFieldComponent = TextField,
   keyboardIcon = <KeyboardIcon />,
   variant,
-  emptyLabel,
+  emptyInputText: emptyLabel,
   hideOpenPickerButton,
   ignoreInvalidInputs,
   onFocus,
@@ -45,7 +45,7 @@ export const KeyboardDateInput: React.FC<DateInputProps> = ({
   const getInputValue = () =>
     getDisplayDate(rawValue, utils, {
       inputFormat,
-      emptyLabel,
+      emptyInputText: emptyLabel,
     });
 
   const [innerInputValue, setInnerInputValue] = React.useState<string | null>(getInputValue());

--- a/lib/src/_shared/PickerToolbar.tsx
+++ b/lib/src/_shared/PickerToolbar.tsx
@@ -48,7 +48,7 @@ interface PickerToolbarProps
       | 'isMobileKeyboardViewOpen'
       | 'toggleMobileKeyboardView'
     > {
-  title: string;
+  toolbarTitle: string;
   landscapeDirection?: 'row' | 'column';
   isLandscape: boolean;
   penIconClassName?: string;
@@ -63,7 +63,7 @@ function defaultGetKeyboardInputSwitchingButtonText(isKeyboardInputOpen: boolean
 const PickerToolbar: React.SFC<PickerToolbarProps> = ({
   children,
   isLandscape,
-  title,
+  toolbarTitle,
   landscapeDirection = 'column',
   className = null,
   penIconClassName,
@@ -80,7 +80,9 @@ const PickerToolbar: React.SFC<PickerToolbarProps> = ({
       className={clsx(classes.toolbar, { [classes.toolbarLandscape]: isLandscape }, className)}
       {...other}
     >
-      <Typography color="inherit" variant="overline" children={title} />
+      <Typography data-mui-test="picker-toolbar-title" color="inherit" variant="overline">
+        {toolbarTitle}
+      </Typography>
       <Grid
         container
         justify="space-between"

--- a/lib/src/_shared/PureDateInput.tsx
+++ b/lib/src/_shared/PureDateInput.tsx
@@ -22,7 +22,7 @@ export interface DateInputProps
    * Message displaying in read-only text field when null passed
    * @default ' '
    */
-  emptyLabel?: string;
+  emptyInputText?: string;
   /** Icon displaying for open picker button */
   keyboardIcon?: React.ReactNode;
   /**
@@ -91,7 +91,7 @@ export const PureDateInput: React.FC<DateInputProps> = ({
   openPicker: onOpen,
   TextFieldComponent = TextField,
   variant,
-  emptyLabel,
+  emptyInputText: emptyLabel,
   keyboardIcon,
   hideOpenPickerButton,
   ignoreInvalidInputs,
@@ -111,7 +111,7 @@ export const PureDateInput: React.FC<DateInputProps> = ({
 
   const inputValue = getDisplayDate(rawValue, utils, {
     inputFormat,
-    emptyLabel,
+    emptyInputText: emptyLabel,
   });
 
   return (

--- a/lib/src/_shared/PureDateInput.tsx
+++ b/lib/src/_shared/PureDateInput.tsx
@@ -16,8 +16,6 @@ export interface DateInputProps
   onChange: (date: MaterialUiPickersDate | null, keyboardInputValue?: string) => void;
   openPicker: () => void;
   validationError?: React.ReactNode;
-  /** Dynamic formatter of text field value @DateIOType */
-  labelFunc?: (date: MaterialUiPickersDate, invalidLabel: string) => string;
   /** Override input component */
   TextFieldComponent?: React.ComponentType<TextFieldProps>;
   /**
@@ -87,7 +85,7 @@ export type ExportedDateInputProps = Omit<
 
 export const PureDateInput: React.FC<DateInputProps> = ({
   onChange,
-  inputFormat: format,
+  inputFormat,
   rifmFormatter,
   acceptRegex: refuse,
   mask,
@@ -100,7 +98,6 @@ export const PureDateInput: React.FC<DateInputProps> = ({
   variant,
   emptyLabel,
   invalidLabel,
-  labelFunc,
   keyboardIcon,
   hideOpenPickerButton,
   ignoreInvalidInputs,
@@ -119,10 +116,9 @@ export const PureDateInput: React.FC<DateInputProps> = ({
   );
 
   const inputValue = getDisplayDate(rawValue, utils, {
-    inputFormat: format,
+    inputFormat,
     emptyLabel,
     invalidLabel,
-    labelFunc,
   });
 
   return (

--- a/lib/src/_shared/PureDateInput.tsx
+++ b/lib/src/_shared/PureDateInput.tsx
@@ -19,15 +19,10 @@ export interface DateInputProps
   /** Override input component */
   TextFieldComponent?: React.ComponentType<TextFieldProps>;
   /**
-   * Message displaying in text field, if null passed
+   * Message displaying in read-only text field when null passed
    * @default ' '
    */
   emptyLabel?: string;
-  /**
-   * Message displaying in text field if date is invalid (doesn't work in keyboard mode)
-   * @default 'unknown'
-   */
-  invalidLabel?: string;
   /** Icon displaying for open picker button */
   keyboardIcon?: React.ReactNode;
   /**
@@ -97,7 +92,6 @@ export const PureDateInput: React.FC<DateInputProps> = ({
   TextFieldComponent = TextField,
   variant,
   emptyLabel,
-  invalidLabel,
   keyboardIcon,
   hideOpenPickerButton,
   ignoreInvalidInputs,
@@ -118,7 +112,6 @@ export const PureDateInput: React.FC<DateInputProps> = ({
   const inputValue = getDisplayDate(rawValue, utils, {
     inputFormat,
     emptyLabel,
-    invalidLabel,
   });
 
   return (

--- a/lib/src/_shared/PureDateInput.tsx
+++ b/lib/src/_shared/PureDateInput.tsx
@@ -9,20 +9,10 @@ import { IconButtonProps } from '@material-ui/core/IconButton';
 import { InputAdornmentProps } from '@material-ui/core/InputAdornment';
 import { getDisplayDate, getTextFieldAriaText } from '../_helpers/text-field-helper';
 
-export type NotOverridableProps =
-  | 'openPicker'
-  | 'inputValue'
-  | 'onChange'
-  | 'format'
-  | 'validationError'
-  | 'format'
-  | 'rawValue'
-  | 'forwardedRef';
-
 export interface DateInputProps
   extends ExtendMui<TextFieldProps, 'onError' | 'onChange' | 'value'> {
   rawValue: ParsableDate;
-  format: string;
+  inputFormat: string;
   onChange: (date: MaterialUiPickersDate | null, keyboardInputValue?: string) => void;
   openPicker: () => void;
   validationError?: React.ReactNode;
@@ -84,11 +74,20 @@ export interface DateInputProps
   ignoreInvalidInputs?: boolean;
 }
 
-export type ExportedDateInputProps = Omit<DateInputProps, NotOverridableProps>;
+export type ExportedDateInputProps = Omit<
+  DateInputProps,
+  | 'openPicker'
+  | 'inputValue'
+  | 'onChange'
+  | 'inputFormat'
+  | 'validationError'
+  | 'rawValue'
+  | 'forwardedRef'
+>;
 
 export const PureDateInput: React.FC<DateInputProps> = ({
   onChange,
-  format,
+  inputFormat: format,
   rifmFormatter,
   acceptRegex: refuse,
   mask,
@@ -120,7 +119,7 @@ export const PureDateInput: React.FC<DateInputProps> = ({
   );
 
   const inputValue = getDisplayDate(rawValue, utils, {
-    format,
+    inputFormat: format,
     emptyLabel,
     invalidLabel,
     labelFunc,

--- a/lib/src/_shared/hooks/usePickerState.ts
+++ b/lib/src/_shared/hooks/usePickerState.ts
@@ -9,10 +9,10 @@ import { useCallback, useDebugValue, useEffect, useMemo, useState } from 'react'
 
 const useValueToDate = (
   utils: IUtils<MaterialUiPickersDate>,
-  { value, initialFocusedDate }: BasePickerProps
+  { value, defaultHighlight }: BasePickerProps
 ) => {
   const now = useNow();
-  const date = utils.date(value || initialFocusedDate || now);
+  const date = utils.date(value || defaultHighlight || now);
 
   return date && utils.isValid(date) ? date : now;
 };

--- a/lib/src/_shared/hooks/usePickerState.ts
+++ b/lib/src/_shared/hooks/usePickerState.ts
@@ -20,13 +20,13 @@ const useValueToDate = (
 function useDateValues(props: BasePickerProps) {
   const utils = useUtils();
   const date = useValueToDate(utils, props);
-  const format = props.format;
+  const inputFormat = props.inputFormat;
 
-  if (!format) {
+  if (!inputFormat) {
     throw new Error('format prop is required');
   }
 
-  return { date, format };
+  return { date, inputFormat };
 }
 
 export const FORCE_FINISH_PICKER = Symbol('Force closing picker, used for accessibility ');
@@ -35,7 +35,7 @@ export function usePickerState(props: BasePickerProps) {
   const { autoOk, disabled, readOnly, onAccept, onChange, onError, value } = props;
 
   const utils = useUtils();
-  const { date, format } = useDateValues(props);
+  const { date, inputFormat } = useDateValues(props);
   const [pickerDate, setPickerDate] = useState(date);
 
   // Mobile keyboard view is a special case.
@@ -67,14 +67,14 @@ export function usePickerState(props: BasePickerProps) {
 
   const wrapperProps = useMemo(
     () => ({
-      format,
+      format: inputFormat,
       open: isOpen,
       onClear: () => acceptDate(null, true),
       onAccept: () => acceptDate(pickerDate, true),
       onSetToday: () => setPickerDate(utils.date()),
       onDismiss: () => setIsOpen(false),
     }),
-    [acceptDate, format, isOpen, pickerDate, setIsOpen, utils]
+    [acceptDate, inputFormat, isOpen, pickerDate, setIsOpen, utils]
   );
 
   const pickerProps = useMemo(
@@ -123,12 +123,12 @@ export function usePickerState(props: BasePickerProps) {
   const inputProps = useMemo(
     () => ({
       onChange,
-      format,
+      inputFormat,
       rawValue: value,
       validationError,
       openPicker: () => !readOnly && !disabled && setIsOpen(true),
     }),
-    [disabled, format, onChange, readOnly, setIsOpen, validationError, value]
+    [disabled, inputFormat, onChange, readOnly, setIsOpen, validationError, value]
   );
 
   const pickerState = { pickerProps, inputProps, wrapperProps };

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,3 +1,5 @@
+import { DayProps as DayPropsType } from './views/Calendar/Day';
+
 export * from './DatePicker';
 
 export * from './TimePicker';
@@ -8,7 +10,9 @@ export { Calendar } from './views/Calendar/Calendar';
 
 export * from './views/Calendar/CalendarView';
 
-export { default as Day } from './views/Calendar/Day';
+export { Day } from './views/Calendar/Day';
+
+export type DayProps = DayPropsType;
 
 export { default as TimePickerView, ClockView } from './views/Clock/ClockView';
 

--- a/lib/src/typings/BasePicker.tsx
+++ b/lib/src/typings/BasePicker.tsx
@@ -19,7 +19,7 @@ export interface BasePickerProps {
   /** Make picker read only */
   readOnly?: boolean;
   /** Date that will be initially highlighted if null was passed */
-  initialFocusedDate?: ParsableDate;
+  defaultHighlight?: ParsableDate;
   /** Callback fired when date is accepted @DateIOType */
   onAccept?: (date: MaterialUiPickersDate) => void;
   /** Callback fired when new error should be displayed

--- a/lib/src/typings/BasePicker.tsx
+++ b/lib/src/typings/BasePicker.tsx
@@ -44,7 +44,7 @@ export interface BasePickerProps {
    * Mobile picker title, displaying in the toolbar
    * @default "SELECT DATE"
    */
-  title?: string;
+  toolbarTitle?: string;
   /**
    * Compare dates by the exact timestamp, instead of start/end of date
    * @default false

--- a/lib/src/typings/BasePicker.tsx
+++ b/lib/src/typings/BasePicker.tsx
@@ -13,7 +13,7 @@ export interface BasePickerProps {
    */
   autoOk?: boolean;
   /** Format string */
-  format?: string;
+  inputFormat?: string;
   /** Disable picker and text field */
   disabled?: boolean;
   /** Make picker read only */

--- a/lib/src/views/Calendar/Calendar.tsx
+++ b/lib/src/views/Calendar/Calendar.tsx
@@ -24,11 +24,11 @@ export interface ExportedCalendarProps extends Pick<DayProps, 'showDaysOutsideCu
    * @default false
    */
   disableFuture?: boolean;
-  /** Custom renderer for day, check [DayComponentProps api](/api/Day) @DateIOType */
+  /** Custom renderer for day. Check [DayComponentProps api](https://material-ui-pickers.dev/api/Day) @DateIOType */
   renderDay?: (
     day: MaterialUiPickersDate,
     selectedDate: MaterialUiPickersDate,
-    DayComponentProps: DayProps,
+    DayComponentProps: DayProps
   ) => JSX.Element;
   /**
    * Enables keyboard listener for moving between days in calendar
@@ -196,13 +196,15 @@ export const Calendar: React.FC<CalendarProps> = ({
                   selected: utils.isSameDay(selectedDate, day),
                   showDaysOutsideCurrentMonth,
                   focusable:
-                  Boolean(nowFocusedDay) &&
-                  utils.toJsDate(nowFocusedDay).getDate() === utils.toJsDate(day).getDate(),
+                    Boolean(nowFocusedDay) &&
+                    utils.toJsDate(nowFocusedDay).getDate() === utils.toJsDate(day).getDate(),
                 };
 
-                let dayComponent = renderDay
-                  ? renderDay(day, selectedDate, dayProps)
-                  : <Day {...dayProps} />
+                let dayComponent = renderDay ? (
+                  renderDay(day, selectedDate, dayProps)
+                ) : (
+                  <Day {...dayProps} />
+                );
 
                 return (
                   <DayWrapper

--- a/lib/src/views/Calendar/Calendar.tsx
+++ b/lib/src/views/Calendar/Calendar.tsx
@@ -9,7 +9,8 @@ import { findClosestEnabledDate } from '../../_helpers/date-utils';
 import { makeStyles, useTheme, Typography } from '@material-ui/core';
 import { useGlobalKeyDown, keycode } from '../../_shared/hooks/useKeyDown';
 
-export interface ExportedCalendarProps extends Pick<DayProps, 'showDaysOutsideCurrentMonth'> {
+export interface ExportedCalendarProps
+  extends Pick<DayProps, 'disableHighlightToday' | 'showDaysOutsideCurrentMonth'> {
   /** Calendar Date @DateIOType */
   date: MaterialUiPickersDate;
   /** Calendar onChange */
@@ -108,6 +109,7 @@ export const Calendar: React.FC<CalendarProps> = ({
   reduceAnimations,
   allowKeyboardControl,
   isDateDisabled,
+  disableHighlightToday,
   showDaysOutsideCurrentMonth,
 }) => {
   const now = useNow();
@@ -194,6 +196,7 @@ export const Calendar: React.FC<CalendarProps> = ({
                   hidden: !isDayInCurrentMonth,
                   isInCurrentMonth: isDayInCurrentMonth,
                   selected: utils.isSameDay(selectedDate, day),
+                  disableHighlightToday,
                   showDaysOutsideCurrentMonth,
                   focusable:
                     Boolean(nowFocusedDay) &&

--- a/lib/src/views/Calendar/Calendar.tsx
+++ b/lib/src/views/Calendar/Calendar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import Day, { DayProps } from './Day';
 import DayWrapper from './DayWrapper';
 import SlideTransition, { SlideDirection } from './SlideTransition';
+import { Day, DayProps } from './Day';
 import { MaterialUiPickersDate } from '../../typings/date';
 import { useUtils, useNow } from '../../_shared/hooks/useUtils';
 import { PickerOnChangeFn } from '../../_shared/hooks/useViews';

--- a/lib/src/views/Calendar/CalendarHeader.tsx
+++ b/lib/src/views/Calendar/CalendarHeader.tsx
@@ -195,34 +195,6 @@ export const CalendarHeader: React.SFC<CalendarHeaderProps> = ({
             isLeftDisabled={isPreviousMonthDisabled}
             isRightDisabled={isNextMonthDisabled}
           />
-          {/* <div>
-            <IconButton
-              data-mui-test="previous-month"
-              size="small"
-              aria-label={leftArrowButtonText}
-              {...leftArrowButtonProps}
-              disabled={isPreviousMonthDisabled}
-              onClick={selectPreviousMonth}
-              className={clsx(
-                classes.iconButton,
-                classes.previousMonthButton,
-                leftArrowButtonProps?.className
-              )}
-            >
-              {isRtl ? rightArrowIcon : leftArrowIcon}
-            </IconButton>
-
-            <IconButton
-              size="small"
-              aria-label={rightArrowButtonText}
-              {...rightArrowButtonProps}
-              disabled={isNextMonthDisabled}
-              onClick={selectNextMonth}
-              className={clsx(classes.iconButton, rightArrowButtonProps?.className)}
-            >
-              {isRtl ? leftArrowIcon : rightArrowIcon}
-            </IconButton>
-          </div> */}
         </Fade>
       </div>
     </>

--- a/lib/src/views/Calendar/Day.tsx
+++ b/lib/src/views/Calendar/Day.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import clsx from 'clsx';
+import { ExtendMui } from '../../typings/helpers';
 import { useUtils } from '../../_shared/hooks/useUtils';
 import { MaterialUiPickersDate } from '../../typings/date';
 import { makeStyles, fade } from '@material-ui/core/styles';
 import { ButtonBase, ButtonBaseProps } from '@material-ui/core';
 
+const daySize = 36;
 export const useStyles = makeStyles(
   theme => ({
     day: {
-      margin: '1px 2px',
-      width: 36,
-      height: 36,
+      width: daySize + 4,
+      height: daySize + 2,
       borderRadius: '50%',
       padding: 0,
       color: theme.palette.text.primary,
@@ -27,6 +28,14 @@ export const useStyles = makeStyles(
           backgroundColor: theme.palette.primary.dark,
         },
       },
+    },
+    dayWithMargin: {
+      margin: '1px 2px',
+      width: daySize,
+      height: daySize,
+    },
+    dayOutsideMonth: {
+      color: theme.palette.text.hint
     },
     hidden: {
       opacity: 0,
@@ -60,7 +69,7 @@ export const useStyles = makeStyles(
   { name: 'MuiPickersDay' }
 );
 
-export interface DayProps extends ButtonBaseProps {
+export interface DayProps extends ExtendMui<ButtonBaseProps> {
   /** The date to show */
   day: MaterialUiPickersDate;
   /** Is focused by keyboard navigation */
@@ -70,7 +79,7 @@ export interface DayProps extends ButtonBaseProps {
   /** Is day in current month */
   isInCurrentMonth: boolean;
   /** Is switching month animation going on right now */
-  isAnimating: boolean;
+  isAnimating?: boolean;
   /** Is today? */
   isToday?: boolean;
   /** Disabled? */
@@ -79,9 +88,17 @@ export interface DayProps extends ButtonBaseProps {
   selected?: boolean;
   /** Is keyboard control and focus management enabled */
   allowKeyboardControl?: boolean;
+  /** Disable margin between days, useful for displaying range of days */
+  disableMargin?: boolean;
+  /**
+   * Display disabled dates outside the current month
+   * @default false
+   */
+  showDaysOutsideCurrentMonth?: boolean;
 }
 
 export const Day: React.FC<DayProps> = ({
+  className,
   day,
   disabled,
   isInCurrentMonth,
@@ -91,24 +108,20 @@ export const Day: React.FC<DayProps> = ({
   focusable = false,
   isAnimating,
   onFocus,
+  disableMargin = false,
   allowKeyboardControl,
+  showDaysOutsideCurrentMonth = false,
   ...other
 }) => {
   const ref = React.useRef<HTMLButtonElement>(null);
   const utils = useUtils();
   const classes = useStyles();
-  const className = clsx(classes.day, {
-    [classes.hidden]: !isInCurrentMonth,
-    [classes.today]: isToday,
-    [classes.daySelected]: selected,
-    [classes.dayDisabled]: disabled,
-  });
 
   React.useEffect(() => {
     if (
       focused &&
-      !isAnimating &&
       !disabled &&
+      !isAnimating &&
       isInCurrentMonth &&
       ref.current &&
       allowKeyboardControl
@@ -125,7 +138,18 @@ export const Day: React.FC<DayProps> = ({
       data-mui-test="day"
       aria-label={utils.format(day, 'fullDate')}
       tabIndex={focused || focusable ? 0 : -1}
-      className={className}
+      className={clsx(
+        classes.day,
+        {
+          [classes.today]: isToday,
+          [classes.daySelected]: selected,
+          [classes.dayDisabled]: disabled,
+          [classes.dayWithMargin]: !disableMargin,
+          [classes.hidden]: !isInCurrentMonth && !showDaysOutsideCurrentMonth,
+          [classes.dayOutsideMonth]: !isInCurrentMonth && showDaysOutsideCurrentMonth,
+        },
+        className
+      )}
       onFocus={e => {
         if (!focused && onFocus) {
           onFocus(e);

--- a/lib/src/views/Calendar/Day.tsx
+++ b/lib/src/views/Calendar/Day.tsx
@@ -35,7 +35,7 @@ export const useStyles = makeStyles(
       height: daySize,
     },
     dayOutsideMonth: {
-      color: theme.palette.text.hint
+      color: theme.palette.text.hint,
     },
     hidden: {
       opacity: 0,
@@ -95,6 +95,10 @@ export interface DayProps extends ExtendMui<ButtonBaseProps> {
    * @default false
    */
   showDaysOutsideCurrentMonth?: boolean;
+  /** Disable highlighting today date with a circle
+   * @default false
+   */
+  disableHighlightToday?: boolean;
 }
 
 export const Day: React.FC<DayProps> = ({
@@ -110,6 +114,7 @@ export const Day: React.FC<DayProps> = ({
   onFocus,
   disableMargin = false,
   allowKeyboardControl,
+  disableHighlightToday = false,
   showDaysOutsideCurrentMonth = false,
   ...other
 }) => {
@@ -141,10 +146,10 @@ export const Day: React.FC<DayProps> = ({
       className={clsx(
         classes.day,
         {
-          [classes.today]: isToday,
           [classes.daySelected]: selected,
           [classes.dayDisabled]: disabled,
           [classes.dayWithMargin]: !disableMargin,
+          [classes.today]: !disableHighlightToday && isToday,
           [classes.hidden]: !isInCurrentMonth && !showDaysOutsideCurrentMonth,
           [classes.dayOutsideMonth]: !isInCurrentMonth && showDaysOutsideCurrentMonth,
         },

--- a/lib/src/views/Calendar/Day.tsx
+++ b/lib/src/views/Calendar/Day.tsx
@@ -182,5 +182,3 @@ Day.defaultProps = {
   isToday: false,
   selected: false,
 };
-
-export default Day;

--- a/lib/src/views/Calendar/DayWrapper.tsx
+++ b/lib/src/views/Calendar/DayWrapper.tsx
@@ -21,7 +21,7 @@ const DayWrapper: React.FC<DayWrapperProps> = ({
   ...other
 }) => {
   const handleSelection = (isFinish: symbol | boolean) => {
-    if (dayInCurrentMonth && !disabled) {
+    if (!disabled) {
       onSelect(value, isFinish);
     }
   };

--- a/lib/src/wrappers/MobileWrapper.tsx
+++ b/lib/src/wrappers/MobileWrapper.tsx
@@ -29,7 +29,7 @@ export interface InnerMobileWrapperProps {
    */
   todayLabel?: React.ReactNode;
   /**
-   * If true today button will be displayed <b>Note*</b> that clear button has higher priority
+   * If true today button will be displayed. **Note** that clear button has higher priority
    * @default false
    */
   showTodayButton?: boolean;


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->
This PR is a part of vNext #1293 development 

## Description

### New props 
* `toolbarFormat` - easily customize date string displaying in toolbar (#1345)
* `disableHighlightToday` - disable highlighting of today date with a circle 
* `showDaysOutsideCurrentMonth` - show days outside of current month in calendar
* `disableMargin` - (only `Day` prop) disable margin between days, useful for range displaying when days are linked together with background color

### Remove props
* `labelFunc` - completely unusable function with current keyboard input design
* `invalidLabel` - pretty same, unusable with keyboard input, use `error` and `helperText` instead

### Renames
* `format` => `inputFormat` 
* `emptyLabel` => `emptyInputText` 
* `initialFocusedDate` => `defaultHighlight` 
* `title` => `toolbarTitle` (+ make it accept value from `label` as default)

### Change signatures
* `renderDay` 
```ts
(date: DateIOType, selectedDate: DateIOType, dayInCurrentMonth: boolean, defaultDay: React.ReactNode) => React.ReactNode 
```
```ts
(date: DateIOType, selectedDate: DateIOType,  DayComponentProps:  DayProps) => React.ReactNode 
```
#### Motivation:
Better customization of the day displaying, by allowing to spread down and override any props we need, before it was possible only by `React.cloneElement`, but it was not so powerful like spreading props down. This also better from performance perspective when overriding days, because we are not rendering day bides ourself if user will render something different.
```tsx
  renderDay={(day, selectedDate, DayComponentProps) => {
     return (
        <Badge overlap="circle" badgeContent={isSelected ? '🌚' : undefined}>
          <Day {...DayComponentProps} isToday disableMargin aria-label="Something"  />
        </Badge>
     );
  }}
```
