### PR TITLE
update `"@date-io/date-fns"` and `"date-fns"`

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.8.4",
-    "@date-io/date-fns": "^2.1.0",
+    "@date-io/date-fns": "^1.3.13",
     "@date-io/dayjs": "^2.1.0",
     "@date-io/luxon": "^2.1.0",
     "@date-io/moment": "^2.1.0",
@@ -97,7 +97,7 @@
     "codecov": "^3.6.5",
     "cross-env": "^5.2.0",
     "cypress-react-unit-test": "^2.4.3",
-    "date-fns": "^2.0.0-alpha.27",
+    "date-fns": "^2.9.0",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "eslint-plugin-react": "^7.12.4",


### PR DESCRIPTION
- Update `"@date-io/date-fns": "^2.1.0"`  to `"@date-io/date-fns": "^1.3.13"`.
- Update `"date-fns": "^2.0.0-alpha.27"`  to `"date-fns": "^2.9.0"`.
As Datepicke was breaking because of `@date-io/date-fns` new version.

<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

This PR closes #19860

## Description
