### PR TITLE
Fix import statements for adapters.

### DIFF
--- a/docs/pages/getting-started/installation.mdx
+++ b/docs/pages/getting-started/installation.mdx
@@ -38,9 +38,9 @@ be used at the root of your component tree, or at the highest level you wish the
 import { LocalizationProvider } from '@material-ui/pickers';
 
 // pick an adapter for your date library
-import MomentUtils from '@material-ui-pickers/adapter/moment';
-import DateFnsUtils from '@material-ui-pickers/adapter/date-fns';
-import LuxonUtils from '@material-ui-pickers/adapter/luxon';
+import MomentUtils from '@material-ui/pickers/adapter/moment';
+import DateFnsUtils from '@material-ui/pickers/adapter/date-fns';
+import LuxonUtils from '@material-ui/pickers/adapter/luxon';
 
 function App() {
   return (


### PR DESCRIPTION
Import statements now refer to `@material-ui/pickers` instead of `@material-ui-pickers`.