### PR TITLE
Fix core@v4.9.9 support with createSvgIcon

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,7 @@
     "@date-io/hijri": "^2.2.0",
     "@date-io/jalaali": "^2.0.0",
     "@mapbox/rehype-prism": "^0.4.0",
-    "@material-ui/core": "^4.9.7",
+    "@material-ui/core": "^4.9.9",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/pickers": "^4.0.0-alpha.1",
     "@types/fuzzy-search": "^2.1.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -32,7 +32,7 @@
     "email": "dmtr.kovalenko@outlook.com"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.0.0",
+    "@material-ui/core": "^4.9.9",
     "@types/react": "^16.8.6",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
@@ -77,7 +77,7 @@
     "@babel/preset-env": "^7.6.0",
     "@babel/preset-react": "^7.0.0",
     "@cypress/webpack-preprocessor": "^4.1.1",
-    "@material-ui/core": "^4.9.7",
+    "@material-ui/core": "^4.9.9",
     "@material-ui/icons": "^4.9.1",
     "@types/enzyme": "^3.10.5",
     "@types/enzyme-adapter-react-16": "^1.0.3",

--- a/lib/rollup.config.js
+++ b/lib/rollup.config.js
@@ -16,6 +16,7 @@ const input = './src/index.ts';
 const globals = {
   react: 'React',
   'react-dom': 'ReactDOM',
+  '@material-ui/core/utils': 'material-ui.utils',
   '@material-ui/core/Button': 'material-ui.Button',
   '@material-ui/core/ButtonBase': 'material-ui.ButtonBase',
   '@material-ui/core/CircularProgress': 'material-ui.CircularProgress',

--- a/lib/src/_shared/icons/ArrowDropDownIcon.tsx
+++ b/lib/src/_shared/icons/ArrowDropDownIcon.tsx
@@ -1,4 +1,4 @@
 import React from 'react';
-import createSvgIcon from '@material-ui/core/internal/svg-icons/createSvgIcon';
+import { createSvgIcon } from '@material-ui/core/utils';
 
 export const ArrowDropDownIcon = createSvgIcon(<path d="M7 10l5 5 5-5z" />, 'ArrowDropDownIcon');

--- a/lib/src/_shared/icons/ArrowLeftIcon.tsx
+++ b/lib/src/_shared/icons/ArrowLeftIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import createSvgIcon from '@material-ui/core/internal/svg-icons/createSvgIcon';
+import { createSvgIcon } from '@material-ui/core/utils';
 
 export const ArrowLeftIcon = createSvgIcon(
   <>

--- a/lib/src/_shared/icons/ArrowRightIcon.tsx
+++ b/lib/src/_shared/icons/ArrowRightIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import createSvgIcon from '@material-ui/core/internal/svg-icons/createSvgIcon';
+import { createSvgIcon } from '@material-ui/core/utils';
 
 export const ArrowRightIcon = createSvgIcon(
   <>

--- a/lib/src/_shared/icons/ClockIcon.tsx
+++ b/lib/src/_shared/icons/ClockIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import createSvgIcon from '@material-ui/core/internal/svg-icons/createSvgIcon';
+import { createSvgIcon } from '@material-ui/core/utils';
 
 export default createSvgIcon(
   <React.Fragment>

--- a/lib/src/_shared/icons/DateRangeIcon.tsx
+++ b/lib/src/_shared/icons/DateRangeIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import createSvgIcon from '@material-ui/core/internal/svg-icons/createSvgIcon';
+import { createSvgIcon } from '@material-ui/core/utils';
 
 export const DateRangeIcon = createSvgIcon(
   <>

--- a/lib/src/_shared/icons/KeyboardIcon.tsx
+++ b/lib/src/_shared/icons/KeyboardIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import createSvgIcon from '@material-ui/core/internal/svg-icons/createSvgIcon';
+import { createSvgIcon } from '@material-ui/core/utils';
 
 export const KeyboardIcon = createSvgIcon(
   <>

--- a/lib/src/_shared/icons/PenIcon.tsx
+++ b/lib/src/_shared/icons/PenIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import createSvgIcon from '@material-ui/core/internal/svg-icons/createSvgIcon';
+import { createSvgIcon } from '@material-ui/core/utils';
 
 export const PenIcon = createSvgIcon(
   <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />,

--- a/lib/src/_shared/icons/TimeIcon.tsx
+++ b/lib/src/_shared/icons/TimeIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import createSvgIcon from '@material-ui/core/internal/svg-icons/createSvgIcon';
+import { createSvgIcon } from '@material-ui/core/utils';
 
 export const TimeIcon = createSvgIcon(
   <>

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -4,11 +4,3 @@ declare module '@date-io/type' {
 
   export type DateType = Moment | DateTime | Date;
 }
-
-declare module '@material-ui/core/internal/svg-icons/createSvgIcon' {
-  import * as React from 'react';
-  import { SvgIconProps } from '@material-ui/core';
-
-  declare const createSvgIcon: (path: React.ReactNode, name: string) => React.FC<SvgIconProps>;
-  export default createSvgIcon;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1626,10 +1626,10 @@
     refractor "^2.3.0"
     unist-util-visit "^1.1.3"
 
-"@material-ui/core@^4.9.7":
-  version "4.9.7"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.9.7.tgz#0c1caf123278770f34c5d8e9ecd9e1314f87a621"
-  integrity sha512-RTRibZgq572GHEskMAG4sP+bt3P3XyIkv3pOTR8grZAW2rSUd6JoGZLRM4S2HkuO7wS7cAU5SpU2s1EsmTgWog==
+"@material-ui/core@^4.9.9":
+  version "4.9.9"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.9.9.tgz#902dc37eeb415dd3288feb2c92e0dc27d9caed48"
+  integrity sha512-Gp0UdJLxPEnkn7O0QpJ2/LOeIuT8nX9e6CjQFuLnOy10rUGjRsOZ2T170Y057xdUmw1VNE+0bvkkO6dOghxt4g==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@material-ui/styles" "^4.9.6"


### PR DESCRIPTION
Update import of `createSvgIcon` according to closes #1619.