### PR TITLE
Better recognition of touch devices

### DIFF
--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -1142,9 +1142,9 @@
     },
     "desktopModeMediaQuery": {
       "defaultValue": {
-        "value": "\"(hover: hover)\""
+        "value": "\""
       },
-      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@example \"(min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
+      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@media (pointer: fine)\"\n@example \"\n@media (min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
       "name": "desktopModeMediaQuery",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",
@@ -1918,9 +1918,9 @@
     },
     "desktopModeMediaQuery": {
       "defaultValue": {
-        "value": "\"(hover: hover)\""
+        "value": "\""
       },
-      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@example \"(min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
+      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@media (pointer: fine)\"\n@example \"\n@media (min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
       "name": "desktopModeMediaQuery",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",
@@ -3018,9 +3018,9 @@
     },
     "desktopModeMediaQuery": {
       "defaultValue": {
-        "value": "\"(hover: hover)\""
+        "value": "\""
       },
-      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@example \"(min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
+      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@media (pointer: fine)\"\n@example \"\n@media (min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
       "name": "desktopModeMediaQuery",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",
@@ -3548,9 +3548,9 @@
     },
     "desktopModeMediaQuery": {
       "defaultValue": {
-        "value": "\"(hover: hover)\""
+        "value": "\""
       },
-      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@example \"(min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
+      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@media (pointer: fine)\"\n@example \"\n@media (min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
       "name": "desktopModeMediaQuery",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -1152,7 +1152,7 @@
       },
       "required": false,
       "type": {
-        "name": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\""
+        "name": "string"
       }
     },
     "dateAdapter": {
@@ -1928,7 +1928,7 @@
       },
       "required": false,
       "type": {
-        "name": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\""
+        "name": "string"
       }
     },
     "dateAdapter": {
@@ -3028,7 +3028,7 @@
       },
       "required": false,
       "type": {
-        "name": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\""
+        "name": "string"
       }
     },
     "dateAdapter": {
@@ -3558,7 +3558,7 @@
       },
       "required": false,
       "type": {
-        "name": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\""
+        "name": "string"
       }
     },
     "disableHighlightToday": {

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -1142,9 +1142,9 @@
     },
     "desktopModeBreakpoint": {
       "defaultValue": {
-        "value": "'md'"
+        "value": "'sm'"
       },
-      "description": "Breakpoint when `Desktop` mode will be changed to `Mobile`",
+      "description": "Breakpoint when `Mobile` mode will be changed to `Desktop`",
       "name": "desktopModeBreakpoint",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",
@@ -1918,9 +1918,9 @@
     },
     "desktopModeBreakpoint": {
       "defaultValue": {
-        "value": "'md'"
+        "value": "'sm'"
       },
-      "description": "Breakpoint when `Desktop` mode will be changed to `Mobile`",
+      "description": "Breakpoint when `Mobile` mode will be changed to `Desktop`",
       "name": "desktopModeBreakpoint",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",
@@ -3018,9 +3018,9 @@
     },
     "desktopModeBreakpoint": {
       "defaultValue": {
-        "value": "'md'"
+        "value": "'sm'"
       },
-      "description": "Breakpoint when `Desktop` mode will be changed to `Mobile`",
+      "description": "Breakpoint when `Mobile` mode will be changed to `Desktop`",
       "name": "desktopModeBreakpoint",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",
@@ -3548,9 +3548,9 @@
     },
     "desktopModeBreakpoint": {
       "defaultValue": {
-        "value": "'md'"
+        "value": "'sm'"
       },
-      "description": "Breakpoint when `Desktop` mode will be changed to `Mobile`",
+      "description": "Breakpoint when `Mobile` mode will be changed to `Desktop`",
       "name": "desktopModeBreakpoint",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -1140,12 +1140,12 @@
         "name": "Partial<PopoverProps>"
       }
     },
-    "desktopModeBreakpoint": {
+    "desktopModeMediaQuery": {
       "defaultValue": {
-        "value": "'sm'"
+        "value": "\"(hover: hover)\""
       },
-      "description": "Breakpoint when `Mobile` mode will be changed to `Desktop`",
-      "name": "desktopModeBreakpoint",
+      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@example \"(min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
+      "name": "desktopModeMediaQuery",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",
         "name": "ResponsiveWrapperProps"
@@ -1916,12 +1916,12 @@
         "name": "Partial<PopoverProps>"
       }
     },
-    "desktopModeBreakpoint": {
+    "desktopModeMediaQuery": {
       "defaultValue": {
-        "value": "'sm'"
+        "value": "\"(hover: hover)\""
       },
-      "description": "Breakpoint when `Mobile` mode will be changed to `Desktop`",
-      "name": "desktopModeBreakpoint",
+      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@example \"(min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
+      "name": "desktopModeMediaQuery",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",
         "name": "ResponsiveWrapperProps"
@@ -3016,12 +3016,12 @@
         "name": "Partial<PopoverProps>"
       }
     },
-    "desktopModeBreakpoint": {
+    "desktopModeMediaQuery": {
       "defaultValue": {
-        "value": "'sm'"
+        "value": "\"(hover: hover)\""
       },
-      "description": "Breakpoint when `Mobile` mode will be changed to `Desktop`",
-      "name": "desktopModeBreakpoint",
+      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@example \"(min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
+      "name": "desktopModeMediaQuery",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",
         "name": "ResponsiveWrapperProps"
@@ -3546,12 +3546,12 @@
         "name": "() => void"
       }
     },
-    "desktopModeBreakpoint": {
+    "desktopModeMediaQuery": {
       "defaultValue": {
-        "value": "'sm'"
+        "value": "\"(hover: hover)\""
       },
-      "description": "Breakpoint when `Mobile` mode will be changed to `Desktop`",
-      "name": "desktopModeBreakpoint",
+      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@example \"(min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
+      "name": "desktopModeMediaQuery",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",
         "name": "ResponsiveWrapperProps"

--- a/e2e/integration/VisualRegression.spec.ts
+++ b/e2e/integration/VisualRegression.spec.ts
@@ -12,7 +12,7 @@ describe('Visual Regression', () => {
     {
       url: '/demo/datepicker',
       name: 'DatePicker demo',
-      hardResponsive: true,
+      withRealTouchDevice: true,
       withDarkTheme: true,
       scenarios: {
         'Opened datepicker': () => {
@@ -26,7 +26,7 @@ describe('Visual Regression', () => {
     {
       url: '/demo/timepicker',
       name: 'TimePicker demo',
-      responsive: true,
+      withRealTouchDevice: true,
       withDarkTheme: true,
       scenarios: {
         'Opened timepicker': () => {
@@ -40,7 +40,7 @@ describe('Visual Regression', () => {
     {
       url: '/demo/datetime-picker',
       name: 'DateTimePicker demo',
-      responsive: true,
+      withRealTouchDevice: true,
       withDarkTheme: true,
       scenarios: {
         'Opened datetimepicker': () => {
@@ -88,7 +88,7 @@ describe('Visual Regression', () => {
       }
 
       if (page.scenarios) {
-        const defaultWidthForScenarios = page.hardResponsive ? [1280] : [1280, 375];
+        const defaultWidthForScenarios = page.withRealTouchDevice ? [1280] : [1280, 375];
 
         Object.entries(page.scenarios).forEach(([name, execute]) => {
           if (!execute || typeof execute !== 'function') {
@@ -101,7 +101,7 @@ describe('Visual Regression', () => {
               cy.percySnapshot(`${page.name}: ${name}`, { widths: defaultWidthForScenarios });
             });
 
-            if (page.hardResponsive) {
+            if (page.withRealTouchDevice) {
               it(`${page.name} scenario: ${name} on mobile`, () => {
                 cy.viewport('iphone-x');
 
@@ -119,7 +119,7 @@ describe('Visual Regression', () => {
               });
             }
 
-            if (page.withDarkTheme && page.hardResponsive) {
+            if (page.withDarkTheme && page.withRealTouchDevice) {
               it(`${page.name} scenario: ${name} on mobile in dark theme`, () => {
                 cy.viewport('iphone-x');
                 cy.toggleTheme();

--- a/lib/src/DateRangePicker/DateRangePicker.tsx
+++ b/lib/src/DateRangePicker/DateRangePicker.tsx
@@ -10,8 +10,8 @@ import { DateRange as DateRangeType, RangeInput } from './RangeTypes';
 import { DesktopPopperWrapper } from '../wrappers/DesktopPopperWrapper';
 import { MuiPickersAdapter, useUtils } from '../_shared/hooks/useUtils';
 import { makeWrapperComponent } from '../wrappers/makeWrapperComponent';
+import { ResponsivePopperWrapper } from '../wrappers/ResponsiveWrapper';
 import { SomeWrapper, ExtendWrapper, StaticWrapper } from '../wrappers/Wrapper';
-import { ResponsivePopperWrapper, ResponsiveWrapper } from '../wrappers/ResponsiveWrapper';
 import { DateRangePickerView, ExportedDateRangePickerViewProps } from './DateRangePickerView';
 import { DateRangePickerInput, ExportedDateRangePickerInputProps } from './DateRangePickerInput';
 

--- a/lib/src/DateRangePicker/DateRangePicker.tsx
+++ b/lib/src/DateRangePicker/DateRangePicker.tsx
@@ -7,11 +7,11 @@ import { parsePickerInputValue } from '../_helpers/date-utils';
 import { usePickerState } from '../_shared/hooks/usePickerState';
 import { AllSharedPickerProps } from '../Picker/SharedPickerProps';
 import { DateRange as DateRangeType, RangeInput } from './RangeTypes';
-import { ResponsivePopperWrapper } from '../wrappers/ResponsiveWrapper';
 import { DesktopPopperWrapper } from '../wrappers/DesktopPopperWrapper';
 import { MuiPickersAdapter, useUtils } from '../_shared/hooks/useUtils';
 import { makeWrapperComponent } from '../wrappers/makeWrapperComponent';
 import { SomeWrapper, ExtendWrapper, StaticWrapper } from '../wrappers/Wrapper';
+import { ResponsivePopperWrapper, ResponsiveWrapper } from '../wrappers/ResponsiveWrapper';
 import { DateRangePickerView, ExportedDateRangePickerViewProps } from './DateRangePickerView';
 import { DateRangePickerInput, ExportedDateRangePickerInputProps } from './DateRangePickerInput';
 

--- a/lib/src/__tests__/DatePicker.test.tsx
+++ b/lib/src/__tests__/DatePicker.test.tsx
@@ -20,7 +20,7 @@ describe('e2e - DatePicker default year format', () => {
       <DatePicker
         DialogProps={{}}
         PopoverProps={{}}
-        desktopModeBreakpoint="xs"
+        desktopModeMediaQuery="(min-width:720px)"
         value={utilsToUse.date('2018-01-01T00:00:00.000')}
         onChange={onChangeMock}
         views={['year']}

--- a/lib/src/constants/dimensions.ts
+++ b/lib/src/constants/dimensions.ts
@@ -7,3 +7,5 @@ export const VIEW_HEIGHT = 358;
 export const DAY_SIZE = 36;
 
 export const DAY_MARGIN = 2;
+
+export const IS_TOUCH_DEVICE_MEDIA = '@media (pointer: fine)';

--- a/lib/src/wrappers/DesktopPopperWrapper.tsx
+++ b/lib/src/wrappers/DesktopPopperWrapper.tsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles(theme => ({
     transformOrigin: 'top center',
     '&:focus': {
       outline: 'auto',
-      '@media (pointer:coarse)': {
+      '@media (hover: none)': {
         outline: 0,
       },
     },

--- a/lib/src/wrappers/DesktopPopperWrapper.tsx
+++ b/lib/src/wrappers/DesktopPopperWrapper.tsx
@@ -11,6 +11,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { InnerMobileWrapperProps } from './MobileWrapper';
 import { InnerDesktopWrapperProps } from './DesktopWrapper';
 import { WrapperVariantContext } from './WrapperVariantContext';
+import { IS_TOUCH_DEVICE_MEDIA } from '../constants/dimensions';
 import { KeyboardDateInput } from '../_shared/KeyboardDateInput';
 import { useGlobalKeyDown, keycode } from '../_shared/hooks/useKeyDown';
 import { TransitionProps } from '@material-ui/core/transitions/transition';
@@ -36,7 +37,7 @@ const useStyles = makeStyles(theme => ({
     transformOrigin: 'top center',
     '&:focus': {
       outline: 'auto',
-      '@media (hover: none)': {
+      [IS_TOUCH_DEVICE_MEDIA]: {
         outline: 0,
       },
     },

--- a/lib/src/wrappers/DesktopWrapper.tsx
+++ b/lib/src/wrappers/DesktopWrapper.tsx
@@ -7,6 +7,7 @@ import { StaticWrapperProps } from './StaticWrapper';
 import { makeStyles } from '@material-ui/core/styles';
 import { InnerMobileWrapperProps } from './MobileWrapper';
 import { WrapperVariantContext } from './WrapperVariantContext';
+import { IS_TOUCH_DEVICE_MEDIA } from '../constants/dimensions';
 import { InnerDesktopPopperWrapperProps } from './DesktopPopperWrapper';
 
 export interface InnerDesktopWrapperProps {
@@ -23,7 +24,7 @@ const useStyles = makeStyles({
   popover: {
     '&:focus': {
       outline: 'auto',
-      '@media (hover: none)': {
+      [IS_TOUCH_DEVICE_MEDIA]: {
         outline: 0,
       },
     },

--- a/lib/src/wrappers/DesktopWrapper.tsx
+++ b/lib/src/wrappers/DesktopWrapper.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles({
   popover: {
     '&:focus': {
       outline: 'auto',
-      '@media (pointer:coarse)': {
+      '@media (hover: none)': {
         outline: 0,
       },
     },

--- a/lib/src/wrappers/ResponsiveWrapper.tsx
+++ b/lib/src/wrappers/ResponsiveWrapper.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { useTheme } from '@material-ui/core/styles';
 import { MobileWrapperProps, MobileWrapper } from './MobileWrapper';
 import { DesktopWrapperProps, DesktopWrapper } from './DesktopWrapper';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
@@ -10,10 +9,11 @@ export interface ResponsiveWrapperProps
   extends DesktopWrapperProps,
     DesktopPopperWrapperProps,
     MobileWrapperProps {
-  /** Breakpoint when `Mobile` mode will be changed to `Desktop`
-   * @default 'sm'
+  /** Css media query when `Mobile` mode will be changed to `Desktop`
+   * @default "(hover: hover)"
+   * @example "(min-width: 720px)" or theme.breakpoints.up("sm")
    */
-  desktopModeBreakpoint?: Breakpoint;
+  desktopModeMediaQuery?: Breakpoint;
 }
 
 export const makeResponsiveWrapper = (
@@ -21,7 +21,7 @@ export const makeResponsiveWrapper = (
   MobileWrapperComponent: React.FC<MobileWrapperProps>
 ) => {
   const ResponsiveWrapper: React.FC<ResponsiveWrapperProps> = ({
-    desktopModeBreakpoint = 'sm',
+    desktopModeMediaQuery = '(hover: hover)',
     okLabel,
     cancelLabel,
     clearLabel,
@@ -35,8 +35,7 @@ export const makeResponsiveWrapper = (
     displayStaticWrapperAs,
     ...other
   }) => {
-    const theme = useTheme();
-    const isDesktop = useMediaQuery(theme.breakpoints.up(desktopModeBreakpoint));
+    const isDesktop = useMediaQuery(desktopModeMediaQuery);
 
     return isDesktop ? (
       <DesktopWrapperComponent

--- a/lib/src/wrappers/ResponsiveWrapper.tsx
+++ b/lib/src/wrappers/ResponsiveWrapper.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { MobileWrapperProps, MobileWrapper } from './MobileWrapper';
 import { DesktopWrapperProps, DesktopWrapper } from './DesktopWrapper';
-import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 import { DesktopPopperWrapperProps, DesktopPopperWrapper } from './DesktopPopperWrapper';
 
 export interface ResponsiveWrapperProps
@@ -13,7 +12,7 @@ export interface ResponsiveWrapperProps
    * @default "(hover: hover)"
    * @example "(min-width: 720px)" or theme.breakpoints.up("sm")
    */
-  desktopModeMediaQuery?: Breakpoint;
+  desktopModeMediaQuery?: string;
 }
 
 export const makeResponsiveWrapper = (

--- a/lib/src/wrappers/ResponsiveWrapper.tsx
+++ b/lib/src/wrappers/ResponsiveWrapper.tsx
@@ -10,8 +10,8 @@ export interface ResponsiveWrapperProps
   extends DesktopWrapperProps,
     DesktopPopperWrapperProps,
     MobileWrapperProps {
-  /** Breakpoint when `Desktop` mode will be changed to `Mobile`
-   * @default 'md'
+  /** Breakpoint when `Mobile` mode will be changed to `Desktop`
+   * @default 'sm'
    */
   desktopModeBreakpoint?: Breakpoint;
 }
@@ -21,7 +21,7 @@ export const makeResponsiveWrapper = (
   MobileWrapperComponent: React.FC<MobileWrapperProps>
 ) => {
   const ResponsiveWrapper: React.FC<ResponsiveWrapperProps> = ({
-    desktopModeBreakpoint = 'md',
+    desktopModeBreakpoint = 'sm',
     okLabel,
     cancelLabel,
     clearLabel,

--- a/lib/src/wrappers/ResponsiveWrapper.tsx
+++ b/lib/src/wrappers/ResponsiveWrapper.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
+import { IS_TOUCH_DEVICE_MEDIA } from '../constants/dimensions';
 import { MobileWrapperProps, MobileWrapper } from './MobileWrapper';
 import { DesktopWrapperProps, DesktopWrapper } from './DesktopWrapper';
 import { DesktopPopperWrapperProps, DesktopPopperWrapper } from './DesktopPopperWrapper';
@@ -9,8 +10,8 @@ export interface ResponsiveWrapperProps
     DesktopPopperWrapperProps,
     MobileWrapperProps {
   /** Css media query when `Mobile` mode will be changed to `Desktop`
-   * @default "(hover: hover)"
-   * @example "(min-width: 720px)" or theme.breakpoints.up("sm")
+   * @default "@media (pointer: fine)"
+   * @example "@media (min-width: 720px)" or theme.breakpoints.up("sm")
    */
   desktopModeMediaQuery?: string;
 }
@@ -20,7 +21,7 @@ export const makeResponsiveWrapper = (
   MobileWrapperComponent: React.FC<MobileWrapperProps>
 ) => {
   const ResponsiveWrapper: React.FC<ResponsiveWrapperProps> = ({
-    desktopModeMediaQuery = '(hover: hover)',
+    desktopModeMediaQuery = IS_TOUCH_DEVICE_MEDIA,
     okLabel,
     cancelLabel,
     clearLabel,


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

This PR closes #1649 <!-- Please refer issue number here, if exists -->
Also closes #1664

## Description
Use `media (pointer: fine)` (https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer) which is the best way to determine touch devices. So use it to render mobile wrapper and hide focus outline. 

> P.S. It is not supported in IE but it is fine because we are falling back to desktop mode :) 
