### PR TITLE
[docs] Use 3001 over 3000 to avoid conflict

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "chrome",
       "request": "launch",
       "name": "Launch Chrome against localhost",
-      "url": "http://localhost:3000",
+      "url": "http://localhost:3001",
       "webRoot": "${workspaceFoler}"
     }
   ]

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "next",
+    "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start",
     "generate-backers": "node scripts/generate-backers.js",


### PR DESCRIPTION
Allows running the mono-repository with the picker docs in dev mode at the same time.