### PR TITLE
Align DateRangePicker inputs by baseline

### DIFF
--- a/lib/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/lib/src/DateRangePicker/DateRangePickerInput.tsx
@@ -14,7 +14,7 @@ export const useStyles = makeStyles(
   theme => ({
     rangeInputsContainer: {
       display: 'flex',
-      alignItems: 'center',
+      alignItems: 'baseline',
       [theme.breakpoints.down('xs')]: {
         flexDirection: 'column',
       },


### PR DESCRIPTION
In particular, this affects the positioning of the "to" in between the two boxes. It doesn't make a difference when the pickers use outlined styling (like in the demo), but it does fix the positioning with the standard styling.