### PR TITLE
[docs] Fix DateFnsAdapter import docs typo

### DIFF
--- a/docs/pages/getting-started/usage.mdx
+++ b/docs/pages/getting-started/usage.mdx
@@ -17,7 +17,7 @@ import { CODESANDBOX_EXAMPLE_ID } from '_constants';
 
 ```jsx
 import React, { useState } from 'react';
-import DateFnsAdapter from "@material-ui/pickers/adapter/date-fns"; // choose your lib
+import DateFnsAdapter from '@material-ui/pickers/adapter/date-fns'; // choose your lib
 import { DatePicker, TimePicker, DateTimePicker, LocalizationProvider } from '@material-ui/pickers';
 
 function App() {

--- a/docs/pages/getting-started/usage.mdx
+++ b/docs/pages/getting-started/usage.mdx
@@ -17,14 +17,14 @@ import { CODESANDBOX_EXAMPLE_ID } from '_constants';
 
 ```jsx
 import React, { useState } from 'react';
-import DateFnsUtils from '@material-ui-pickers/adapter/date-fns'; // choose your lib
+import DateFnsAdapter from "@material-ui/pickers/adapter/date-fns"; // choose your lib
 import { DatePicker, TimePicker, DateTimePicker, LocalizationProvider } from '@material-ui/pickers';
 
 function App() {
   const [selectedDate, handleDateChange] = useState(new Date());
 
   return (
-    <LocalizationProvider dateAdapter={DateFnsUtils}>
+    <LocalizationProvider dateAdapter={DateFnsAdapter}>
       <DatePicker value={selectedDate} onChange={date => handleDateChange(date)} />
       <TimePicker value={selectedDate} onChange={date => handleDateChange(date)} />
       <DateTimePicker value={selectedDate} onChange={date => handleDateChange(date)} />


### PR DESCRIPTION
The Adapter comes from  "@material-ui/pickers/adapter/date-fns";  instead of '@material-ui-pickers/adapter/date-fns';

<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->
