### PR TITLE
[DateRangePicker] renderInput for date range

### DIFF
--- a/docs/pages/demo/daterangepicker/BasicDateRangePicker.example.tsx
+++ b/docs/pages/demo/daterangepicker/BasicDateRangePicker.example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { TextField } from '@material-ui/core';
-import { DateRangePicker, DateRange } from '@material-ui/pickers';
+import { DateRangePicker, DateRange, DateRangeDelimiter } from '@material-ui/pickers';
 
 function BasicDateRangePicker() {
   const [selectedDate, handleDateChange] = React.useState<DateRange>([null, null]);
@@ -11,7 +11,13 @@ function BasicDateRangePicker() {
       endText="Check-out"
       value={selectedDate}
       onChange={date => handleDateChange(date)}
-      renderInput={props => <TextField {...props} />}
+      renderInput={(startProps, endProps) => (
+        <>
+          <TextField {...startProps} />
+          <DateRangeDelimiter> to </DateRangeDelimiter>
+          <TextField {...endProps} />
+        </>
+      )}
     />
   );
 }

--- a/docs/pages/demo/daterangepicker/CalendarsDateRangePicker.example.tsx
+++ b/docs/pages/demo/daterangepicker/CalendarsDateRangePicker.example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Grid from '@material-ui/core/Grid';
 import { Typography, TextField } from '@material-ui/core';
-import { DateRangePicker, DateRange } from '@material-ui/pickers';
+import { DateRangePicker, DateRangeDelimiter, DateRange } from '@material-ui/pickers';
 
 function CalendarsDateRangePicker() {
   const [selectedDate, handleDateChange] = React.useState<DateRange>([null, null]);
@@ -13,21 +13,41 @@ function CalendarsDateRangePicker() {
         calendars={1}
         value={selectedDate}
         onChange={date => handleDateChange(date)}
-        renderInput={props => <TextField {...props} />}
+        renderInput={(startProps, endProps) => (
+          <>
+            <TextField {...startProps} />
+            <DateRangeDelimiter> to </DateRangeDelimiter>
+            <TextField {...endProps} />
+          </>
+        )}
       />
+
       <Typography gutterBottom> 2 calendars</Typography>
       <DateRangePicker
         calendars={2}
         value={selectedDate}
         onChange={date => handleDateChange(date)}
-        renderInput={props => <TextField {...props} />}
+        renderInput={(startProps, endProps) => (
+          <>
+            <TextField {...startProps} />
+            <DateRangeDelimiter> to </DateRangeDelimiter>
+            <TextField {...endProps} />
+          </>
+        )}
       />
+
       <Typography gutterBottom> 3 calendars</Typography>
       <DateRangePicker
         calendars={3}
         value={selectedDate}
         onChange={date => handleDateChange(date)}
-        renderInput={props => <TextField {...props} />}
+        renderInput={(startProps, endProps) => (
+          <>
+            <TextField {...startProps} />
+            <DateRangeDelimiter> to </DateRangeDelimiter>
+            <TextField {...endProps} />
+          </>
+        )}
       />
     </Grid>
   );

--- a/docs/pages/demo/daterangepicker/MinMaxDateRangePicker.example.tsx
+++ b/docs/pages/demo/daterangepicker/MinMaxDateRangePicker.example.tsx
@@ -5,7 +5,7 @@ import { Moment } from 'moment';
 import { DateTime } from 'luxon';
 import { TextField } from '@material-ui/core';
 import { makeJSDateObject } from '../../../utils/helpers';
-import { DateRangePicker, DateRange } from '@material-ui/pickers';
+import { DateRangePicker, DateRangeDelimiter, DateRange } from '@material-ui/pickers';
 
 function getWeeksAfter(date: Moment | DateTime | Dayjs | Date, amount: number) {
   // TODO: replace with implementation for your date library
@@ -21,7 +21,13 @@ function MinMaxDateRangePicker() {
       value={selectedRange}
       maxDate={getWeeksAfter(selectedRange[0], 4)}
       onChange={date => handleDateChange(date)}
-      renderInput={props => <TextField {...props} />}
+      renderInput={(startProps, endProps) => (
+        <>
+          <TextField {...startProps} />
+          <DateRangeDelimiter> to </DateRangeDelimiter>
+          <TextField {...endProps} />
+        </>
+      )}
     />
   );
 }

--- a/docs/pages/demo/daterangepicker/ResponsiveDateRangePicker.example.tsx
+++ b/docs/pages/demo/daterangepicker/ResponsiveDateRangePicker.example.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { TextField } from '@material-ui/core';
-import { MobileDateRangePicker, DesktopDateRangePicker, DateRange } from '@material-ui/pickers';
+import {
+  MobileDateRangePicker,
+  DateRangeDelimiter,
+  DesktopDateRangePicker,
+  DateRange,
+} from '@material-ui/pickers';
 
 function ResponsiveDateRangePicker() {
   const [selectedDate, handleDateChange] = React.useState<DateRange>([null, null]);
@@ -11,14 +16,26 @@ function ResponsiveDateRangePicker() {
         startText="Mobile start"
         value={selectedDate}
         onChange={date => handleDateChange(date)}
-        renderInput={props => <TextField {...props} />}
+        renderInput={(startProps, endProps) => (
+          <>
+            <TextField {...startProps} />
+            <DateRangeDelimiter> to </DateRangeDelimiter>
+            <TextField {...endProps} />
+          </>
+        )}
       />
 
       <DesktopDateRangePicker
         startText="Desktop start"
         value={selectedDate}
         onChange={date => handleDateChange(date)}
-        renderInput={props => <TextField {...props} />}
+        renderInput={(startProps, endProps) => (
+          <>
+            <TextField {...startProps} />
+            <DateRangeDelimiter> to </DateRangeDelimiter>
+            <TextField {...endProps} />
+          </>
+        )}
       />
     </>
   );

--- a/docs/pages/demo/daterangepicker/StaticDateRangePicker.example.tsx
+++ b/docs/pages/demo/daterangepicker/StaticDateRangePicker.example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { TextField } from '@material-ui/core';
-import { StaticDateRangePicker, DateRange } from '@material-ui/pickers';
+import { StaticDateRangePicker, DateRangeDelimiter, DateRange } from '@material-ui/pickers';
 
 function StaticDateRangePickerExample() {
   const [selectedDate, handleDateChange] = React.useState<DateRange>([null, null]);
@@ -11,14 +11,26 @@ function StaticDateRangePickerExample() {
         displayStaticWrapperAs="desktop"
         value={selectedDate}
         onChange={date => handleDateChange(date)}
-        renderInput={props => <TextField {...props} />}
+        renderInput={(startProps, endProps) => (
+          <>
+            <TextField {...startProps} />
+            <DateRangeDelimiter> to </DateRangeDelimiter>
+            <TextField {...endProps} />
+          </>
+        )}
       />
 
       <StaticDateRangePicker
         displayStaticWrapperAs="mobile"
         value={selectedDate}
         onChange={date => handleDateChange(date)}
-        renderInput={props => <TextField {...props} />}
+        renderInput={(startProps, endProps) => (
+          <>
+            <TextField {...startProps} />
+            <DateRangeDelimiter> to </DateRangeDelimiter>
+            <TextField {...endProps} />
+          </>
+        )}
       />
     </>
   );

--- a/docs/pages/regression/Regression.tsx
+++ b/docs/pages/regression/Regression.tsx
@@ -99,9 +99,15 @@ function Regression() {
       </Typography>
 
       <DateRangePicker
-        {...makeRenderInputProp({ inputProps: { 'data-mui-test': 'desktop-range-picker' } })}
         value={range}
         onChange={changeRange}
+        renderInput={(startProps, endProps) => {
+          <>
+            <TextField {...startProps} />
+            <Typography> to </Typography>
+            <TextField {...endProps} />
+          </>;
+        }}
       />
     </div>
   );

--- a/docs/pages/regression/Regression.tsx
+++ b/docs/pages/regression/Regression.tsx
@@ -3,8 +3,8 @@ import LeftArrowIcon from '@material-ui/icons/KeyboardArrowLeft';
 import RightArrowIcon from '@material-ui/icons/KeyboardArrowRight';
 import { Grid, Typography } from '@material-ui/core';
 import { TextField, TextFieldProps } from '@material-ui/core';
-import { MuiPickersContext, DateRangePicker } from '@material-ui/pickers';
 import { createRegressionDay as createRegressionDayRenderer } from './RegressionDay';
+import { MuiPickersContext, DateRangePicker, DateRangeDelimiter } from '@material-ui/pickers';
 import {
   DateRange,
   MobileDatePicker,
@@ -29,9 +29,6 @@ function Regression() {
     leftArrowIcon: <LeftArrowIcon data-arrow="left" />,
     rightArrowIcon: <RightArrowIcon data-arrow="right" />,
     renderDay: createRegressionDayRenderer(utils!),
-    KeyboardButtonProps: {
-      className: 'keyboard-btn',
-    },
   };
 
   return (
@@ -101,13 +98,13 @@ function Regression() {
       <DateRangePicker
         value={range}
         onChange={changeRange}
-        renderInput={(startProps, endProps) => {
+        renderInput={(startProps, endProps) => (
           <>
-            <TextField {...startProps} />
-            <Typography> to </Typography>
-            <TextField {...endProps} />
-          </>;
-        }}
+            <TextField {...startProps} inputProps={{ 'data-mui-test': 'desktop-range-picker' }} />
+            <DateRangeDelimiter> to </DateRangeDelimiter>
+            <TextField {...endProps} inputProps={{ 'data-mui-test': 'desktop-range-picker-end' }} />
+          </>
+        )}
       />
     </div>
   );

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -845,7 +845,7 @@
     },
     "renderInput": {
       "defaultValue": null,
-      "description": "Override input component",
+      "description": "Render input component. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\nrenderInput={props => <TextField {...props} />}\n````",
       "name": "renderInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -912,10 +912,10 @@
         "name": "Partial<InputAdornmentProps>"
       }
     },
-    "KeyboardButtonProps": {
+    "OpenPickerButtonProps": {
       "defaultValue": null,
       "description": "Props to pass to keyboard adornment button",
-      "name": "KeyboardButtonProps",
+      "name": "OpenPickerButtonProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"
@@ -1621,7 +1621,7 @@
     },
     "renderInput": {
       "defaultValue": null,
-      "description": "Override input component",
+      "description": "Render input component. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\nrenderInput={props => <TextField {...props} />}\n````",
       "name": "renderInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -1688,10 +1688,10 @@
         "name": "Partial<InputAdornmentProps>"
       }
     },
-    "KeyboardButtonProps": {
+    "OpenPickerButtonProps": {
       "defaultValue": null,
       "description": "Props to pass to keyboard adornment button",
-      "name": "KeyboardButtonProps",
+      "name": "OpenPickerButtonProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"
@@ -2721,7 +2721,7 @@
     },
     "renderInput": {
       "defaultValue": null,
-      "description": "Override input component",
+      "description": "Render input component. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\nrenderInput={props => <TextField {...props} />}\n````",
       "name": "renderInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -2788,10 +2788,10 @@
         "name": "Partial<InputAdornmentProps>"
       }
     },
-    "KeyboardButtonProps": {
+    "OpenPickerButtonProps": {
       "defaultValue": null,
       "description": "Props to pass to keyboard adornment button",
-      "name": "KeyboardButtonProps",
+      "name": "OpenPickerButtonProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"
@@ -3680,7 +3680,7 @@
     },
     "renderInput": {
       "defaultValue": null,
-      "description": "Override input component",
+      "description": "Render input component. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\nrenderInput={props => <TextField {...props} />}\n````",
       "name": "renderInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -3747,10 +3747,10 @@
         "name": "Partial<InputAdornmentProps>"
       }
     },
-    "KeyboardButtonProps": {
+    "OpenPickerButtonProps": {
       "defaultValue": null,
       "description": "Props to pass to keyboard adornment button",
-      "name": "KeyboardButtonProps",
+      "name": "OpenPickerButtonProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
         "name": "DateInputProps"

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -3479,58 +3479,6 @@
         "name": "boolean"
       }
     },
-    "onAccept": {
-      "defaultValue": null,
-      "description": "Callback fired when date is accepted",
-      "name": "onAccept",
-      "parent": {
-        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
-        "name": "BasePickerProps"
-      },
-      "required": false,
-      "type": {
-        "name": "((date: DateIOType) => void) & ((date: DateRange) => void)"
-      }
-    },
-    "className": {
-      "defaultValue": null,
-      "description": "className applied to the root component",
-      "name": "className",
-      "parent": {
-        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
-        "name": "BasePickerProps"
-      },
-      "required": false,
-      "type": {
-        "name": "string"
-      }
-    },
-    "onError": {
-      "defaultValue": null,
-      "description": "Callback fired when new error should be displayed\n(!! This is a side effect. Be careful if you want to rerender the component)",
-      "name": "onError",
-      "parent": {
-        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
-        "name": "BasePickerProps"
-      },
-      "required": false,
-      "type": {
-        "name": "((error: ReactNode, value: DateIOType) => void) & ((error: ReactNode, value: RangeInput | DateRange) => void)"
-      }
-    },
-    "onClose": {
-      "defaultValue": null,
-      "description": "On close callback",
-      "name": "onClose",
-      "parent": {
-        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
-        "name": "BasePickerProps"
-      },
-      "required": false,
-      "type": {
-        "name": "() => void"
-      }
-    },
     "autoOk": {
       "defaultValue": {
         "value": "false"
@@ -3559,10 +3507,49 @@
         "name": "any"
       }
     },
+    "onAccept": {
+      "defaultValue": null,
+      "description": "Callback fired when date is accepted",
+      "name": "onAccept",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
+        "name": "BasePickerProps"
+      },
+      "required": false,
+      "type": {
+        "name": "((date: DateIOType) => void) & ((date: DateRange) => void)"
+      }
+    },
+    "onError": {
+      "defaultValue": null,
+      "description": "Callback fired when new error should be displayed\n(!! This is a side effect. Be careful if you want to rerender the component)",
+      "name": "onError",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
+        "name": "BasePickerProps"
+      },
+      "required": false,
+      "type": {
+        "name": "((error: ReactNode, value: DateIOType) => void) & ((error: ReactNode, value: RangeInput | DateRange) => void)"
+      }
+    },
     "onOpen": {
       "defaultValue": null,
       "description": "On open callback",
       "name": "onOpen",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
+        "name": "BasePickerProps"
+      },
+      "required": false,
+      "type": {
+        "name": "() => void"
+      }
+    },
+    "onClose": {
+      "defaultValue": null,
+      "description": "On close callback",
+      "name": "onClose",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
         "name": "BasePickerProps"
@@ -3639,30 +3626,30 @@
         "name": "string"
       }
     },
-    "value": {
+    "className": {
       "defaultValue": null,
-      "description": "Picker value",
-      "name": "value",
+      "description": "className applied to the root component",
+      "name": "className",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
         "name": "BasePickerProps"
       },
-      "required": true,
+      "required": false,
       "type": {
-        "name": "RangeInput"
+        "name": "string"
       }
     },
-    "onChange": {
+    "renderInput": {
       "defaultValue": null,
-      "description": "onChange callback",
-      "name": "onChange",
+      "description": "Render input component for date range. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\n<DateRangePicker\nrenderInput={(startProps, endProps) => (\n<Stack>\n<TextField {...startProps} />\n<Typography> to <Typography>\n<TextField {...endProps} />\n</Stack>;\n)}\n/>\n````",
+      "name": "renderInput",
       "parent": {
-        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
-        "name": "BasePickerProps"
+        "fileName": "material-ui-pickers/lib/src/DateRangePicker/DateRangePickerInput.tsx",
+        "name": "ExportedDateRangePickerInputProps"
       },
       "required": true,
       "type": {
-        "name": "(date: DateRange, keyboardInputValue?: string) => void"
+        "name": "(props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<...>"
       }
     },
     "mask": {
@@ -3678,17 +3665,17 @@
         "name": "string"
       }
     },
-    "renderInput": {
+    "onChange": {
       "defaultValue": null,
-      "description": "Render input component. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\nrenderInput={props => <TextField {...props} />}\n````",
-      "name": "renderInput",
+      "description": "onChange callback",
+      "name": "onChange",
       "parent": {
-        "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
-        "name": "DateInputProps"
+        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
+        "name": "BasePickerProps"
       },
       "required": true,
       "type": {
-        "name": "(props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<...>"
+        "name": "(date: DateRange, keyboardInputValue?: string) => void"
       }
     },
     "emptyInputText": {
@@ -3816,6 +3803,19 @@
       "required": false,
       "type": {
         "name": "(value: any, utils: MuiPickersAdapter) => string"
+      }
+    },
+    "value": {
+      "defaultValue": null,
+      "description": "Picker value",
+      "name": "value",
+      "parent": {
+        "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
+        "name": "BasePickerProps"
+      },
+      "required": true,
+      "type": {
+        "name": "RangeInput"
       }
     },
     "dateAdapter": {

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -3641,7 +3641,7 @@
     },
     "renderInput": {
       "defaultValue": null,
-      "description": "Render input component for date range. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\n<DateRangePicker\nrenderInput={(startProps, endProps) => (\n<Stack>\n<TextField {...startProps} />\n<Typography> to <Typography>\n<TextField {...endProps} />\n</Stack>;\n)}\n/>\n````",
+      "description": "Render input component for date range. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\n<DateRangePicker\nrenderInput={(startProps, endProps) => (\n<>\n<TextField {...startProps} />\n<Typography> to <Typography>\n<TextField {...endProps} />\n</>;\n)}\n/>\n````",
       "name": "renderInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/DateRangePicker/DateRangePickerInput.tsx",

--- a/e2e/integration/DatePicker.spec.ts
+++ b/e2e/integration/DatePicker.spec.ts
@@ -95,7 +95,7 @@ describe('DatePicker', () => {
     });
 
     it('Should open calendar by the keyboard icon', () => {
-      cy.get('.keyboard-btn')
+      cy.get('[data-mui-test="open-picker-from-keyboard"]')
         .first()
         .click();
       cy.get(`[data-day="19/01/2019"]`).click();

--- a/e2e/integration/DateRange.spec.ts
+++ b/e2e/integration/DateRange.spec.ts
@@ -12,6 +12,14 @@ describe('DateRangePicker', () => {
     cy.get('[data-mui-test="DateRangeHighlight"]').should('have.length', 24);
   });
 
+  it('Should close when focused moved outside of picker popper', () => {
+    cy.get('[data-mui-test="desktop-range-picker"]').click();
+    cy.get('div[role="tooltip"]').should('be.visible');
+
+    cy.get('#basic-datepicker').focus();
+    cy.get('div[role="tooltip"]').should('not.be.visible');
+  });
+
   it('Opens and selecting a range on the next month', () => {
     cy.get('[data-mui-test="desktop-range-picker"]').focus();
 

--- a/e2e/integration/DateRange.spec.ts
+++ b/e2e/integration/DateRange.spec.ts
@@ -5,9 +5,7 @@ describe('DateRangePicker', () => {
   });
 
   it('Opens and selecting a range in DateRangePicker', () => {
-    cy.get('[data-mui-test="desktop-range-picker"]')
-      .first()
-      .focus();
+    cy.get('[data-mui-test="desktop-range-picker"]').focus();
     cy.get('[aria-label="Jan 1, 2019"]').click();
     cy.get('[aria-label="Jan 24, 2019"]').click();
 
@@ -15,9 +13,7 @@ describe('DateRangePicker', () => {
   });
 
   it('Opens and selecting a range on the next month', () => {
-    cy.get('[data-mui-test="desktop-range-picker"]')
-      .first()
-      .focus();
+    cy.get('[data-mui-test="desktop-range-picker"]').focus();
 
     cy.get('[aria-label="Jan 1, 2019"]').click();
     cy.get('[data-mui-test="next-arrow-button"]')
@@ -38,13 +34,9 @@ describe('DateRangePicker', () => {
   });
 
   it('Properly handles selection when starting from end', () => {
-    cy.get('[data-mui-test="desktop-range-picker"]')
-      .first()
-      .clear();
+    cy.get('[data-mui-test="desktop-range-picker"]').clear();
 
-    cy.get('[data-mui-test="desktop-range-picker"]')
-      .eq(1)
-      .focus();
+    cy.get('[data-mui-test="desktop-range-picker-end"]').focus();
 
     cy.get('[aria-label="Jan 30, 2019"]')
       .first()
@@ -68,8 +60,7 @@ describe('DateRangePicker', () => {
     cy.contains('June 2019');
     cy.contains('July 2019');
 
-    cy.get('[data-mui-test="desktop-range-picker"]')
-      .eq(1)
+    cy.get('[data-mui-test="desktop-range-picker-end"]')
       .focus()
       .clear()
       .type('08/08/2019');
@@ -112,9 +103,7 @@ describe('DateRangePicker', () => {
     cy.get('[aria-label="Mar 19, 2019"]').click();
 
     // reopen picker
-    cy.get('[data-mui-test="desktop-range-picker"]')
-      .eq(1)
-      .click();
+    cy.get('[data-mui-test="desktop-range-picker-end"]').click();
 
     cy.contains('February 2019');
     cy.contains('March 2019');

--- a/lib/.size-snapshot.json
+++ b/lib/.size-snapshot.json
@@ -1,15 +1,15 @@
 {
   "build/dist/material-ui-pickers.esm.js": {
-    "bundled": 184206,
-    "minified": 99456,
-    "gzipped": 25950,
+    "bundled": 186211,
+    "minified": 100412,
+    "gzipped": 26056,
     "treeshaked": {
       "rollup": {
-        "code": 82029,
-        "import_statements": 2118
+        "code": 82896,
+        "import_statements": 2182
       },
       "webpack": {
-        "code": 91248
+        "code": 92271
       }
     }
   },

--- a/lib/package.json
+++ b/lib/package.json
@@ -51,7 +51,7 @@
     "clsx": "^1.0.2",
     "prop-types": "^15.7.2",
     "react-transition-group": "^4.0.0",
-    "rifm": "^0.10.1"
+    "rifm": "^0.11.0"
   },
   "scripts": {
     "test": "jest",

--- a/lib/src/DateRangePicker/DateRangeDelimiter.tsx
+++ b/lib/src/DateRangePicker/DateRangeDelimiter.tsx
@@ -1,0 +1,5 @@
+import { styled, Typography } from '@material-ui/core';
+
+export const DateRangeDelimiter = styled(Typography)({
+  margin: '0 16px',
+});

--- a/lib/src/DateRangePicker/DateRangeDelimiter.tsx
+++ b/lib/src/DateRangePicker/DateRangeDelimiter.tsx
@@ -1,4 +1,5 @@
-import { styled, Typography } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import { styled } from '@material-ui/core/styles';
 
 export const DateRangeDelimiter = styled(Typography)({
   margin: '0 16px',

--- a/lib/src/DateRangePicker/DateRangePicker.tsx
+++ b/lib/src/DateRangePicker/DateRangePicker.tsx
@@ -5,8 +5,6 @@ import { MobileWrapper } from '../wrappers/MobileWrapper';
 import { DateRangeInputProps } from './DateRangePickerInput';
 import { parsePickerInputValue } from '../_helpers/date-utils';
 import { usePickerState } from '../_shared/hooks/usePickerState';
-import { AllSharedPickerProps } from '../Picker/SharedPickerProps';
-import { DateRange as DateRangeType, RangeInput } from './RangeTypes';
 import { DesktopPopperWrapper } from '../wrappers/DesktopPopperWrapper';
 import { MuiPickersAdapter, useUtils } from '../_shared/hooks/useUtils';
 import { makeWrapperComponent } from '../wrappers/makeWrapperComponent';
@@ -14,6 +12,11 @@ import { ResponsivePopperWrapper } from '../wrappers/ResponsiveWrapper';
 import { SomeWrapper, ExtendWrapper, StaticWrapper } from '../wrappers/Wrapper';
 import { DateRangePickerView, ExportedDateRangePickerViewProps } from './DateRangePickerView';
 import { DateRangePickerInput, ExportedDateRangePickerInputProps } from './DateRangePickerInput';
+import {
+  DateRange as DateRangeType,
+  RangeInput,
+  AllSharedDateRangePickerProps,
+} from './RangeTypes';
 
 export function parseRangeInputValue(
   now: MaterialUiPickersDate,
@@ -69,7 +72,7 @@ export function makeRangePicker<TWrapper extends SomeWrapper>(Wrapper: TWrapper)
     endText = 'End',
     inputFormat: passedInputFormat,
     ...restPropsForTextField
-  }: DateRangePickerProps & AllSharedPickerProps<RangeInput, DateRange> & ExtendWrapper<TWrapper>) {
+  }: DateRangePickerProps & AllSharedDateRangePickerProps & ExtendWrapper<TWrapper>) {
     const utils = useUtils();
     const [currentlySelectingRangeEnd, setCurrentlySelectingRangeEnd] = React.useState<
       'start' | 'end'
@@ -147,3 +150,5 @@ export const DesktopDateRangePicker = makeRangePicker(DesktopPopperWrapper);
 export const MobileDateRangePicker = makeRangePicker(MobileWrapper);
 
 export const StaticDateRangePicker = makeRangePicker(StaticWrapper);
+
+export { DateRangeDelimiter } from './DateRangeDelimiter';

--- a/lib/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/lib/src/DateRangePicker/DateRangePickerInput.tsx
@@ -71,6 +71,8 @@ export const DateRangePickerInput: React.FC<DateRangeInputProps> = ({
   endText,
   readOnly,
   renderInput,
+  TextFieldProps,
+  onBlur,
   ...other
 }) => {
   const utils = useUtils();
@@ -136,6 +138,7 @@ export const DateRangePickerInput: React.FC<DateRangeInputProps> = ({
     onChange: handleStartChange,
     label: startText,
     TextFieldProps: {
+      ...TextFieldProps,
       ref: startRef,
       variant: 'outlined',
       focused: open && currentlySelectingRangeEnd === 'start',
@@ -152,6 +155,7 @@ export const DateRangePickerInput: React.FC<DateRangeInputProps> = ({
     parsedDateValue: end,
     onChange: handleEndChange,
     TextFieldProps: {
+      ...TextFieldProps,
       ref: endRef,
       variant: 'outlined',
       focused: open && currentlySelectingRangeEnd === 'end',
@@ -161,7 +165,11 @@ export const DateRangePickerInput: React.FC<DateRangeInputProps> = ({
   });
 
   return (
-    <div className={classes.rangeInputsContainer} ref={mergeRefs([containerRef, forwardedRef])}>
+    <div
+      onBlur={onBlur}
+      className={classes.rangeInputsContainer}
+      ref={mergeRefs([containerRef, forwardedRef])}
+    >
       {renderInput(startInputProps, endInputProps)}
     </div>
   );

--- a/lib/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/lib/src/DateRangePicker/DateRangePickerInput.tsx
@@ -5,6 +5,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { MaterialUiPickersDate } from '../typings/date';
 import { CurrentlySelectingRangeEndProps } from './RangeTypes';
 import { useMaskedInput } from '../_shared/hooks/useMaskedInput';
+import { WrapperVariantContext } from '../wrappers/WrapperVariantContext';
 import { DateInputProps, MuiTextFieldProps } from '../_shared/PureDateInput';
 import { mergeRefs, executeInTheNextEventLoopTick } from '../_helpers/utils';
 
@@ -79,6 +80,7 @@ export const DateRangePickerInput: React.FC<DateRangeInputProps> = ({
   const classes = useStyles();
   const startRef = React.useRef<HTMLInputElement>(null);
   const endRef = React.useRef<HTMLInputElement>(null);
+  const wrapperVariant = React.useContext(WrapperVariantContext);
 
   React.useEffect(() => {
     if (!open) {
@@ -130,6 +132,7 @@ export const DateRangePickerInput: React.FC<DateRangeInputProps> = ({
     }
   };
 
+  const openOnFocus = wrapperVariant === 'desktop';
   const startInputProps = useMaskedInput({
     ...other,
     readOnly,
@@ -142,8 +145,8 @@ export const DateRangePickerInput: React.FC<DateRangeInputProps> = ({
       ref: startRef,
       variant: 'outlined',
       focused: open && currentlySelectingRangeEnd === 'start',
-      onClick: !readOnly ? openRangeStartSelection : undefined,
-      onFocus: !readOnly ? openRangeStartSelection : undefined,
+      onClick: !openOnFocus ? openRangeStartSelection : undefined,
+      onFocus: openOnFocus ? openRangeStartSelection : undefined,
     },
   });
 
@@ -159,8 +162,8 @@ export const DateRangePickerInput: React.FC<DateRangeInputProps> = ({
       ref: endRef,
       variant: 'outlined',
       focused: open && currentlySelectingRangeEnd === 'end',
-      onClick: !readOnly ? openRangeEndSelection : undefined,
-      onFocus: !readOnly ? openRangeEndSelection : undefined,
+      onClick: !openOnFocus ? openRangeEndSelection : undefined,
+      onFocus: openOnFocus ? openRangeEndSelection : undefined,
     },
   });
 

--- a/lib/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/lib/src/DateRangePicker/DateRangePickerInput.tsx
@@ -34,11 +34,11 @@ export interface ExportedDateRangePickerInputProps {
    * @example ```jsx
    * <DateRangePicker
    * renderInput={(startProps, endProps) => (
-       <Stack>
+       <>
          <TextField {...startProps} />
          <Typography> to <Typography>
          <TextField {...endProps} />
-       </Stack>;
+       </>;
      )}
      />
    * ````

--- a/lib/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/lib/src/DateRangePicker/DateRangePickerInput.tsx
@@ -5,8 +5,9 @@ import { RangeInput, DateRange } from './RangeTypes';
 import { useUtils } from '../_shared/hooks/useUtils';
 import { makeStyles } from '@material-ui/core/styles';
 import { MaterialUiPickersDate } from '../typings/date';
-import { DateInputProps } from '../_shared/PureDateInput';
 import { CurrentlySelectingRangeEndProps } from './RangeTypes';
+import { useMaskedInput } from '../_shared/hooks/useMaskedInput';
+import { DateInputProps, MuiTextFieldProps } from '../_shared/PureDateInput';
 import { mergeRefs, doNothing, executeInTheNextEventLoopTick } from '../_helpers/utils';
 
 export const useStyles = makeStyles(
@@ -36,9 +37,24 @@ export interface ExportedDateRangePickerInputProps {
 export interface DateRangeInputProps
   extends ExportedDateRangePickerInputProps,
     CurrentlySelectingRangeEndProps,
-    Omit<DateInputProps<RangeInput, DateRange>, 'forwardedRef'> {
+    Omit<DateInputProps<RangeInput, DateRange>, 'renderInput' | 'forwardedRef'> {
   startText: React.ReactNode;
   endText: React.ReactNode;
+  /**
+   * Render input component for date range. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props
+   * @example ```jsx
+   * <DateRangePicker
+   * renderInput={(startProps, endProps) => (
+       <Stack>
+         <TextField {...startProps} />
+         <Typography> to <Typography>
+         <TextField {...endProps} />
+       </Stack>;
+     )}
+     />
+   * ````
+   */
+  renderInput: (startProps: MuiTextFieldProps, endProps: MuiTextFieldProps) => React.ReactElement;
   forwardedRef?: React.Ref<HTMLDivElement>;
   containerRef?: React.Ref<HTMLDivElement>;
 }
@@ -115,6 +131,7 @@ export const DateRangePickerInput: React.FC<DateRangeInputProps> = ({
     }
   };
 
+  const startInputProps = useMaskedInput();
   return (
     <div className={classes.rangeInputsContainer} ref={mergeRefs([containerRef, forwardedRef])}>
       <KeyboardDateInput

--- a/lib/src/DateRangePicker/DateRangePickerView.tsx
+++ b/lib/src/DateRangePicker/DateRangePickerView.tsx
@@ -4,7 +4,6 @@ import { MaterialUiPickersDate } from '../typings/date';
 import { BasePickerProps } from '../typings/BasePicker';
 import { calculateRangeChange } from './date-range-manager';
 import { useUtils, useNow } from '../_shared/hooks/useUtils';
-import { DateRangePickerInput } from './DateRangePickerInput';
 import { SharedPickerProps } from '../Picker/SharedPickerProps';
 import { DateRangePickerToolbar } from './DateRangePickerToolbar';
 import { useParsedDate } from '../_shared/hooks/date-helpers-hooks';
@@ -13,6 +12,7 @@ import { FORCE_FINISH_PICKER } from '../_shared/hooks/usePickerState';
 import { DateRangePickerViewMobile } from './DateRangePickerViewMobile';
 import { WrapperVariantContext } from '../wrappers/WrapperVariantContext';
 import { MobileKeyboardInputView } from '../views/MobileKeyboardInputView';
+import { DateRangePickerInput, DateRangeInputProps } from './DateRangePickerInput';
 import { RangeInput, DateRange, CurrentlySelectingRangeEndProps } from './RangeTypes';
 import { ExportedCalendarViewProps, defaultReduceAnimations } from '../views/Calendar/CalendarView';
 import {
@@ -36,7 +36,7 @@ export interface ExportedDateRangePickerViewProps
 interface DateRangePickerViewProps
   extends ExportedDateRangePickerViewProps,
     CurrentlySelectingRangeEndProps,
-    SharedPickerProps<RangeInput, DateRange> {
+    SharedPickerProps<RangeInput, DateRange, DateRangeInputProps> {
   open: boolean;
   startText: React.ReactNode;
   endText: React.ReactNode;
@@ -204,15 +204,7 @@ export const DateRangePickerView: React.FC<DateRangePickerViewProps> = ({
 
       {isMobileKeyboardViewOpen ? (
         <MobileKeyboardInputView>
-          <DateRangePickerInput
-            disableOpenPicker
-            ignoreInvalidInputs
-            startText={startText}
-            endText={endText}
-            currentlySelectingRangeEnd={currentlySelectingRangeEnd}
-            setCurrentlySelectingRangeEnd={setCurrentlySelectingRangeEnd}
-            {...DateInputProps}
-          />
+          <DateRangePickerInput disableOpenPicker ignoreInvalidInputs {...DateInputProps} />
         </MobileKeyboardInputView>
       ) : (
         renderView()

--- a/lib/src/DateRangePicker/RangeTypes.ts
+++ b/lib/src/DateRangePicker/RangeTypes.ts
@@ -1,8 +1,15 @@
 import { ParsableDate } from '../constants/prop-types';
 import { MaterialUiPickersDate } from '../typings/date';
+import { AllSharedPickerProps } from '../Picker/SharedPickerProps';
+import { ExportedDateRangePickerInputProps } from './DateRangePickerInput';
 
 export type RangeInput = [ParsableDate, ParsableDate];
 export type DateRange = [MaterialUiPickersDate, MaterialUiPickersDate];
+export type AllSharedDateRangePickerProps = Omit<
+  AllSharedPickerProps<RangeInput, DateRange>,
+  'renderInput'
+> &
+  ExportedDateRangePickerInputProps;
 
 export interface CurrentlySelectingRangeEndProps {
   currentlySelectingRangeEnd: 'start' | 'end';

--- a/lib/src/Picker/SharedPickerProps.tsx
+++ b/lib/src/Picker/SharedPickerProps.tsx
@@ -1,11 +1,11 @@
-import { WrapperVariant } from '../wrappers/Wrapper';
 import { DateTimePickerView } from '../DateTimePicker';
 import { ParsableDate } from '../constants/prop-types';
 import { BasePickerProps } from '../typings/BasePicker';
 import { MaterialUiPickersDate } from '../typings/date';
+import { ExportedDateInputProps } from '../_shared/PureDateInput';
 import { DateValidationProps } from '../_helpers/text-field-helper';
 import { WithDateAdapterProps } from '../_shared/withDateAdapterProp';
-import { ExportedDateInputProps, DateInputProps } from '../_shared/PureDateInput';
+import { WrapperVariant, DateInputPropsLike } from '../wrappers/Wrapper';
 
 export type AnyPickerView = DateTimePickerView;
 
@@ -20,7 +20,7 @@ export type AllSharedPickerProps<
 export interface SharedPickerProps<TInputValue, TDateValue> {
   isMobileKeyboardViewOpen: boolean;
   toggleMobileKeyboardView: () => void;
-  DateInputProps: Omit<DateInputProps<TInputValue, TDateValue>, 'renderInput'>;
+  DateInputProps: DateInputPropsLike<TInputValue, TDateValue>;
   date: TDateValue;
   onDateChange: (
     date: TDateValue,

--- a/lib/src/Picker/SharedPickerProps.tsx
+++ b/lib/src/Picker/SharedPickerProps.tsx
@@ -20,7 +20,7 @@ export type AllSharedPickerProps<
 export interface SharedPickerProps<TInputValue, TDateValue> {
   isMobileKeyboardViewOpen: boolean;
   toggleMobileKeyboardView: () => void;
-  DateInputProps: DateInputProps<TInputValue, TDateValue>;
+  DateInputProps: Omit<DateInputProps<TInputValue, TDateValue>, 'renderInput'>;
   date: TDateValue;
   onDateChange: (
     date: TDateValue,

--- a/lib/src/Picker/SharedPickerProps.tsx
+++ b/lib/src/Picker/SharedPickerProps.tsx
@@ -17,10 +17,14 @@ export type AllSharedPickerProps<
   WithDateAdapterProps &
   DateValidationProps;
 
-export interface SharedPickerProps<TInputValue, TDateValue> {
+export interface SharedPickerProps<
+  TInputValue,
+  TDateValue,
+  TInputProps = DateInputPropsLike<TInputValue, TDateValue>
+> {
   isMobileKeyboardViewOpen: boolean;
   toggleMobileKeyboardView: () => void;
-  DateInputProps: DateInputPropsLike<TInputValue, TDateValue>;
+  DateInputProps: TInputProps;
   date: TDateValue;
   onDateChange: (
     date: TDateValue,

--- a/lib/src/__tests__/KeyboardDateTimePicker.test.tsx
+++ b/lib/src/__tests__/KeyboardDateTimePicker.test.tsx
@@ -21,7 +21,7 @@ describe('e2e - DesktopDateTimePicker', () => {
         onClose={onCloseMock}
         onOpen={onOpenMock}
         inputFormat={format}
-        KeyboardButtonProps={{ id: 'keyboard-button' }}
+        OpenPickerButtonProps={{ id: 'keyboard-button' }}
         renderInput={props => <TextField {...props} />}
         value={utilsToUse.date('2018-01-01T00:00:00.000Z')}
       />

--- a/lib/src/_shared/KeyboardDateInput.tsx
+++ b/lib/src/_shared/KeyboardDateInput.tsx
@@ -1,105 +1,33 @@
 import * as React from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import InputAdornment from '@material-ui/core/InputAdornment';
-import { Rifm } from 'rifm';
 import { useUtils } from './hooks/useUtils';
 import { CalendarIcon } from './icons/CalendarIcon';
+import { useMaskedInput } from './hooks/useMaskedInput';
 import { DateInputProps, DateInputRefs } from './PureDateInput';
-import { createDelegatedEventHandler } from '../_helpers/utils';
-import {
-  maskedDateFormatter,
-  getDisplayDate,
-  checkMaskIsValidForCurrentFormat,
-  getTextFieldAriaText,
-} from '../_helpers/text-field-helper';
+import { getTextFieldAriaText } from '../_helpers/text-field-helper';
 
 export const KeyboardDateInput: React.FC<DateInputProps & DateInputRefs> = ({
-  disableMaskedInput,
-  rawValue,
-  validationError,
-  KeyboardButtonProps,
-  InputAdornmentProps,
-  openPicker: onOpen,
-  onChange,
-  InputProps,
-  mask,
-  acceptRegex = /[\d]/gi,
-  inputFormat,
-  disabled,
-  rifmFormatter,
   renderInput,
+  openPicker: onOpen,
+  InputProps,
+  InputAdornmentProps,
   openPickerIcon = <CalendarIcon />,
-  emptyInputText: emptyLabel,
+  OpenPickerButtonProps,
   disableOpenPicker: hideOpenPickerButton,
-  ignoreInvalidInputs,
-  forwardedRef,
-  containerRef,
-  readOnly,
-  TextFieldProps,
-  label,
   getOpenDialogAriaText = getTextFieldAriaText,
+  containerRef,
+  forwardedRef,
+  ...other
 }) => {
   const utils = useUtils();
-  const isFocusedRef = React.useRef(false);
-
-  const getInputValue = React.useCallback(
-    () =>
-      getDisplayDate(rawValue, utils, {
-        inputFormat,
-        emptyInputText: emptyLabel,
-      }),
-    [emptyLabel, inputFormat, rawValue, utils]
-  );
-
-  const formatHelperText = utils.getFormatHelperText(inputFormat);
-  const [innerInputValue, setInnerInputValue] = React.useState<string | null>(getInputValue());
-  const shouldUseMaskedInput = React.useMemo(() => {
-    // formatting of dates is a quite slow thing, so do not make useless .format calls
-    if (!mask || disableMaskedInput) {
-      return false;
-    }
-
-    return checkMaskIsValidForCurrentFormat(mask, inputFormat, acceptRegex, utils);
-  }, [acceptRegex, disableMaskedInput, inputFormat, mask, utils]);
-
-  const formatter = React.useMemo(
-    () =>
-      shouldUseMaskedInput && mask ? maskedDateFormatter(mask, acceptRegex) : (st: string) => st,
-    [shouldUseMaskedInput, mask, acceptRegex]
-  );
-
-  React.useEffect(() => {
-    // We do not need to update the input value on keystroke
-    // Because library formatters can change inputs from 12/12/2 to 12/12/0002
-    if ((rawValue === null || utils.isValid(rawValue)) && !isFocusedRef.current) {
-      setInnerInputValue(getInputValue());
-    }
-  }, [rawValue, utils, inputFormat, getInputValue]);
-
-  const handleChange = (text: string) => {
-    const finalString = text === '' || text === mask ? null : text;
-    setInnerInputValue(finalString);
-
-    const date = finalString === null ? null : utils.parse(finalString, inputFormat);
-    if (ignoreInvalidInputs && !utils.isValid(date)) {
-      return;
-    }
-
-    onChange(date, finalString || undefined);
-  };
-
+  const textFieldProps = useMaskedInput(other);
   const adornmentPosition = InputAdornmentProps?.position || 'end';
-  const inputProps = {
-    label,
-    disabled,
+
+  return renderInput({
     ref: containerRef,
     inputRef: forwardedRef,
-    type: shouldUseMaskedInput ? 'tel' : 'text',
-    placeholder: formatHelperText,
-    error: Boolean(validationError),
-    helperText: formatHelperText || validationError,
-    'data-mui-test': 'keyboard-date-input',
-    inputProps: { readOnly },
+    ...textFieldProps,
     InputProps: {
       ...InputProps,
       [`${adornmentPosition}Adornment`]: hideOpenPickerButton ? (
@@ -109,9 +37,9 @@ export const KeyboardDateInput: React.FC<DateInputProps & DateInputRefs> = ({
           <IconButton
             edge={adornmentPosition}
             data-mui-test="open-picker-from-keyboard"
-            disabled={disabled}
-            aria-label={getOpenDialogAriaText(rawValue, utils)}
-            {...KeyboardButtonProps}
+            disabled={other.disabled}
+            aria-label={getOpenDialogAriaText(other.rawValue, utils)}
+            {...OpenPickerButtonProps}
             onClick={onOpen}
           >
             {openPickerIcon}
@@ -119,41 +47,7 @@ export const KeyboardDateInput: React.FC<DateInputProps & DateInputRefs> = ({
         </InputAdornment>
       ),
     },
-    ...TextFieldProps,
-    onFocus: createDelegatedEventHandler(
-      () => (isFocusedRef.current = true),
-      TextFieldProps?.onFocus
-    ),
-    onBlur: createDelegatedEventHandler(
-      () => (isFocusedRef.current = false),
-      TextFieldProps?.onBlur
-    ),
-  };
-
-  if (!shouldUseMaskedInput) {
-    return renderInput({
-      ...inputProps,
-      value: innerInputValue || '',
-      onChange: e => handleChange(e.currentTarget.value),
-    });
-  }
-
-  return (
-    <Rifm
-      key={mask}
-      value={innerInputValue || ''}
-      onChange={handleChange}
-      accept={acceptRegex}
-      format={rifmFormatter || formatter}
-    >
-      {rifmProps =>
-        renderInput({
-          ...inputProps,
-          ...rifmProps,
-        })
-      }
-    </Rifm>
-  );
+  });
 };
 
 export default KeyboardDateInput;

--- a/lib/src/_shared/PureDateInput.tsx
+++ b/lib/src/_shared/PureDateInput.tsx
@@ -8,7 +8,7 @@ import { useUtils, MuiPickersAdapter } from './hooks/useUtils';
 import { InputAdornmentProps } from '@material-ui/core/InputAdornment';
 import { getDisplayDate, getTextFieldAriaText } from '../_helpers/text-field-helper';
 
-type MuiTextFieldProps = TextFieldProps | Omit<TextFieldProps, 'variant'>;
+export type MuiTextFieldProps = TextFieldProps | Omit<TextFieldProps, 'variant'>;
 
 export interface DateInputProps<TInputValue = ParsableDate, TDateValue = MaterialUiPickersDate> {
   open: boolean;
@@ -25,7 +25,12 @@ export interface DateInputProps<TInputValue = ParsableDate, TDateValue = Materia
   TextFieldProps?: Partial<MuiTextFieldProps>;
   // ?? TODO when it will be possible to display "empty" date in datepicker use it instead of ignoring invalid inputs
   ignoreInvalidInputs?: boolean;
-  /** Override input component */
+  /**
+   * Render input component. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props
+   * @example ```jsx
+   * renderInput={props => <TextField {...props} />}
+   * ````
+   */
   renderInput: (props: MuiTextFieldProps) => React.ReactElement;
   /**
    * Message displaying in read-only text field when null passed
@@ -52,7 +57,7 @@ export interface DateInputProps<TInputValue = ParsableDate, TDateValue = Materia
    * Props to pass to keyboard adornment button
    * @type {Partial<IconButtonProps>}
    */
-  KeyboardButtonProps?: Partial<IconButtonProps>;
+  OpenPickerButtonProps?: Partial<IconButtonProps>;
   /** Custom formatter to be passed into Rifm component */
   rifmFormatter?: (str: string) => string;
   /**

--- a/lib/src/_shared/PureDateInput.tsx
+++ b/lib/src/_shared/PureDateInput.tsx
@@ -23,6 +23,8 @@ export interface DateInputProps<TInputValue = ParsableDate, TDateValue = Materia
   label?: TextFieldProps['label'];
   InputProps?: TextFieldProps['InputProps'];
   TextFieldProps?: Partial<MuiTextFieldProps>;
+  // lib/src/wrappers/DesktopPopperWrapper.tsx:87
+  onBlur?: () => void;
   // ?? TODO when it will be possible to display "empty" date in datepicker use it instead of ignoring invalid inputs
   ignoreInvalidInputs?: boolean;
   /**
@@ -89,6 +91,7 @@ export type ExportedDateInputProps<TInputValue, TDateValue> = Omit<
   | 'parsedDateValue'
   | 'open'
   | 'TextFieldProps'
+  | 'onBlur'
 >;
 
 export interface DateInputRefs {

--- a/lib/src/_shared/hooks/useMaskedInput.tsx
+++ b/lib/src/_shared/hooks/useMaskedInput.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { useRifm } from 'rifm';
 import { useUtils } from './useUtils';
-import { DateInputProps } from '../PureDateInput';
 import { createDelegatedEventHandler } from '../../_helpers/utils';
+import { DateInputProps, MuiTextFieldProps } from '../PureDateInput';
 import {
   maskedDateFormatter,
   getDisplayDate,
@@ -38,7 +38,7 @@ export function useMaskedInput({
   readOnly,
   TextFieldProps,
   label,
-}: MaskedInputProps) {
+}: MaskedInputProps): MuiTextFieldProps {
   const utils = useUtils();
   const isFocusedRef = React.useRef(false);
 
@@ -52,7 +52,7 @@ export function useMaskedInput({
   );
 
   const formatHelperText = utils.getFormatHelperText(inputFormat);
-  const [innerInputValue, setInnerInputValue] = React.useState<string | null>(getInputValue());
+  const [innerInputValue, setInnerInputValue] = React.useState<string>(getInputValue());
 
   const shouldUseMaskedInput = React.useMemo(() => {
     // formatting of dates is a quite slow thing, so do not make useless .format calls
@@ -78,7 +78,7 @@ export function useMaskedInput({
   }, [utils, getInputValue, rawValue]);
 
   const handleChange = (text: string) => {
-    const finalString = text === '' || text === mask ? null : text;
+    const finalString = text === '' || text === mask ? '' : text;
     setInnerInputValue(finalString);
 
     const date = finalString === null ? null : utils.parse(finalString, inputFormat);
@@ -90,19 +90,27 @@ export function useMaskedInput({
   };
 
   const rifmProps = useRifm({
-    value: innerInputValue || '',
+    value: innerInputValue,
     onChange: handleChange,
     format: rifmFormatter || formatter,
   });
 
+  const inputStateArgs = shouldUseMaskedInput
+    ? rifmProps
+    : {
+        value: innerInputValue,
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) => handleChange(e.currentTarget.value),
+      };
+
   return {
-    ...(shouldUseMaskedInput ? rifmProps : {}),
+    ...inputStateArgs,
     label,
     disabled,
     type: shouldUseMaskedInput ? 'tel' : 'text',
     placeholder: formatHelperText,
     error: Boolean(validationError),
     helperText: formatHelperText || validationError,
+    // @ts-ignore ??? fix typings for textfield finally
     'data-mui-test': 'keyboard-date-input',
     inputProps: { readOnly },
     ...TextFieldProps,

--- a/lib/src/_shared/hooks/useMaskedInput.tsx
+++ b/lib/src/_shared/hooks/useMaskedInput.tsx
@@ -11,6 +11,7 @@ import {
 
 type MaskedInputProps = Omit<
   DateInputProps,
+  | 'open'
   | 'adornmentPosition'
   | 'renderInput'
   | 'openPicker'
@@ -34,7 +35,6 @@ export function useMaskedInput({
   rifmFormatter,
   emptyInputText: emptyLabel,
   ignoreInvalidInputs,
-
   readOnly,
   TextFieldProps,
   label,

--- a/lib/src/_shared/hooks/useMaskedInput.tsx
+++ b/lib/src/_shared/hooks/useMaskedInput.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import { useRifm } from 'rifm';
+import { useUtils } from './useUtils';
+import { DateInputProps } from '../PureDateInput';
+import { createDelegatedEventHandler } from '../../_helpers/utils';
+import {
+  maskedDateFormatter,
+  getDisplayDate,
+  checkMaskIsValidForCurrentFormat,
+} from '../../_helpers/text-field-helper';
+
+type MaskedInputProps = Omit<
+  DateInputProps,
+  | 'adornmentPosition'
+  | 'renderInput'
+  | 'openPicker'
+  | 'InputProps'
+  | 'InputAdornmentProps'
+  | 'openPickerIcon'
+  | 'disableOpenPicker'
+  | 'getOpenDialogAriaText'
+  | 'OpenPickerButtonProps'
+>;
+
+export function useMaskedInput({
+  disableMaskedInput,
+  rawValue,
+  validationError,
+  onChange,
+  mask,
+  acceptRegex = /[\d]/gi,
+  inputFormat,
+  disabled,
+  rifmFormatter,
+  emptyInputText: emptyLabel,
+  ignoreInvalidInputs,
+
+  readOnly,
+  TextFieldProps,
+  label,
+}: MaskedInputProps) {
+  const utils = useUtils();
+  const isFocusedRef = React.useRef(false);
+
+  const getInputValue = React.useCallback(
+    () =>
+      getDisplayDate(rawValue, utils, {
+        inputFormat,
+        emptyInputText: emptyLabel,
+      }),
+    [emptyLabel, inputFormat, rawValue, utils]
+  );
+
+  const formatHelperText = utils.getFormatHelperText(inputFormat);
+  const [innerInputValue, setInnerInputValue] = React.useState<string | null>(getInputValue());
+  const shouldUseMaskedInput = React.useMemo(() => {
+    // formatting of dates is a quite slow thing, so do not make useless .format calls
+    if (!mask || disableMaskedInput) {
+      return false;
+    }
+
+    return checkMaskIsValidForCurrentFormat(mask, inputFormat, acceptRegex, utils);
+  }, [acceptRegex, disableMaskedInput, inputFormat, mask, utils]);
+
+  const formatter = React.useMemo(
+    () =>
+      shouldUseMaskedInput && mask ? maskedDateFormatter(mask, acceptRegex) : (st: string) => st,
+    [acceptRegex, mask, shouldUseMaskedInput]
+  );
+
+  React.useEffect(() => {
+    // We do not need to update the input value on keystroke
+    // Because library formatters can change inputs from 12/12/2 to 12/12/0002
+    if ((rawValue === null || utils.isValid(rawValue)) && !isFocusedRef.current) {
+      setInnerInputValue(getInputValue());
+    }
+  }, [utils, getInputValue, rawValue]);
+
+  const handleChange = (text: string) => {
+    const finalString = text === '' || text === mask ? null : text;
+    setInnerInputValue(finalString);
+
+    const date = finalString === null ? null : utils.parse(finalString, inputFormat);
+    if (ignoreInvalidInputs && !utils.isValid(date)) {
+      return;
+    }
+
+    onChange(date, finalString || undefined);
+  };
+
+  const rifmProps = useRifm({
+    value: innerInputValue || '',
+    onChange: handleChange,
+    format: rifmFormatter || formatter,
+  });
+
+  return {
+    ...rifmProps,
+    label,
+    disabled,
+    type: shouldUseMaskedInput ? 'tel' : 'text',
+    placeholder: formatHelperText,
+    error: Boolean(validationError),
+    helperText: formatHelperText || validationError,
+    'data-mui-test': 'keyboard-date-input',
+    inputProps: { readOnly },
+
+    ...TextFieldProps,
+    onFocus: createDelegatedEventHandler(
+      () => (isFocusedRef.current = true),
+      TextFieldProps?.onFocus
+    ),
+    onBlur: createDelegatedEventHandler(
+      () => (isFocusedRef.current = false),
+      TextFieldProps?.onBlur
+    ),
+  };
+}

--- a/lib/src/_shared/hooks/useMaskedInput.tsx
+++ b/lib/src/_shared/hooks/useMaskedInput.tsx
@@ -53,6 +53,7 @@ export function useMaskedInput({
 
   const formatHelperText = utils.getFormatHelperText(inputFormat);
   const [innerInputValue, setInnerInputValue] = React.useState<string | null>(getInputValue());
+
   const shouldUseMaskedInput = React.useMemo(() => {
     // formatting of dates is a quite slow thing, so do not make useless .format calls
     if (!mask || disableMaskedInput) {
@@ -95,7 +96,7 @@ export function useMaskedInput({
   });
 
   return {
-    ...rifmProps,
+    ...(shouldUseMaskedInput ? rifmProps : {}),
     label,
     disabled,
     type: shouldUseMaskedInput ? 'tel' : 'text',
@@ -104,7 +105,6 @@ export function useMaskedInput({
     helperText: formatHelperText || validationError,
     'data-mui-test': 'keyboard-date-input',
     inputProps: { readOnly },
-
     ...TextFieldProps,
     onFocus: createDelegatedEventHandler(
       () => (isFocusedRef.current = true),

--- a/lib/src/wrappers/DesktopPopperWrapper.tsx
+++ b/lib/src/wrappers/DesktopPopperWrapper.tsx
@@ -79,13 +79,7 @@ export const DesktopPopperWrapper: React.FC<DesktopPopperWrapperProps> = ({
 
   return (
     <WrapperVariantContext.Provider value="desktop">
-      <KeyboardDateInputComponent
-        {...DateInputProps}
-        containerRef={inputRef}
-        TextFieldProps={{
-          onBlur: handleBlur,
-        }}
-      />
+      <KeyboardDateInputComponent {...DateInputProps} containerRef={inputRef} onBlur={handleBlur} />
 
       <Popper
         transition

--- a/lib/src/wrappers/MobileWrapper.tsx
+++ b/lib/src/wrappers/MobileWrapper.tsx
@@ -78,7 +78,7 @@ export const MobileWrapper: React.FC<MobileWrapperProps> = ({
 }) => {
   return (
     <WrapperVariantContext.Provider value="mobile">
-      <PureDateInputComponent readOnly {...other} {...DateInputProps} />
+      <PureDateInputComponent {...other} {...DateInputProps} />
 
       <ModalDialog
         wider={wider}

--- a/lib/src/wrappers/Wrapper.tsx
+++ b/lib/src/wrappers/Wrapper.tsx
@@ -5,7 +5,7 @@ import { DesktopWrapper, DesktopWrapperProps } from './DesktopWrapper';
 import { ResponsiveWrapper, ResponsiveWrapperProps } from './ResponsiveWrapper';
 import { DesktopPopperWrapper, DesktopPopperWrapperProps } from './DesktopPopperWrapper';
 
-export interface WrapperProps<TInputProps = DateInputProps<any, any>> {
+export interface WrapperProps<TInputProps = Omit<DateInputProps<any, any>, 'renderInput'>> {
   open: boolean;
   onAccept: () => void;
   onDismiss: () => void;

--- a/lib/src/wrappers/Wrapper.tsx
+++ b/lib/src/wrappers/Wrapper.tsx
@@ -5,7 +5,14 @@ import { DesktopWrapper, DesktopWrapperProps } from './DesktopWrapper';
 import { ResponsiveWrapper, ResponsiveWrapperProps } from './ResponsiveWrapper';
 import { DesktopPopperWrapper, DesktopPopperWrapperProps } from './DesktopPopperWrapper';
 
-export interface WrapperProps<TInputProps = Omit<DateInputProps<any, any>, 'renderInput'>> {
+export type DateInputPropsLike<TInputValue, TDateValue> = Omit<
+  DateInputProps<TInputValue, TDateValue>,
+  'renderInput'
+> & {
+  renderInput: (...args: any) => JSX.Element;
+};
+
+export interface WrapperProps<TInputProps = DateInputPropsLike<any, any>> {
   open: boolean;
   onAccept: () => void;
   onDismiss: () => void;

--- a/lib/src/wrappers/makeWrapperComponent.tsx
+++ b/lib/src/wrappers/makeWrapperComponent.tsx
@@ -4,7 +4,7 @@ import { BasePickerProps } from '../typings/BasePicker';
 import { DateInputProps } from '../_shared/PureDateInput';
 import { ResponsiveWrapperProps } from './ResponsiveWrapper';
 import { DateValidationProps } from '../_helpers/text-field-helper';
-import { OmitInnerWrapperProps, SomeWrapper, WrapperProps } from './Wrapper';
+import { OmitInnerWrapperProps, SomeWrapper, WrapperProps, DateInputPropsLike } from './Wrapper';
 
 interface MakePickerOptions<TInputProps> {
   PureDateInputComponent?: React.FC<TInputProps>;
@@ -19,7 +19,7 @@ interface WithWrapperProps<TInputProps = DateInputProps> {
 
 /** Creates a component that rendering modal/popover/nothing and spreading props down to text field */
 export function makeWrapperComponent<
-  TInputProps extends Omit<DateInputProps<TInputValue, TDateValue>, 'renderInput'>,
+  TInputProps extends DateInputPropsLike<TInputValue, TDateValue>,
   TInputValue,
   TDateValue,
   TWrapper extends SomeWrapper = any

--- a/lib/src/wrappers/makeWrapperComponent.tsx
+++ b/lib/src/wrappers/makeWrapperComponent.tsx
@@ -19,7 +19,7 @@ interface WithWrapperProps<TInputProps = DateInputProps> {
 
 /** Creates a component that rendering modal/popover/nothing and spreading props down to text field */
 export function makeWrapperComponent<
-  TInputProps extends DateInputProps<TInputValue, TDateValue>,
+  TInputProps extends Omit<DateInputProps<TInputValue, TDateValue>, 'renderInput'>,
   TInputValue,
   TDateValue,
   TWrapper extends SomeWrapper = any

--- a/yarn.lock
+++ b/yarn.lock
@@ -11682,10 +11682,10 @@ reusify@^1.0.0:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rifm@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/rifm/-/rifm-0.10.1.tgz#2db1b2e006e1fd3540caffd012bdbcd96e5d6e5a"
-  integrity sha512-Y1kCEFNCEkqRlmjHhQ91fVXfv8VxeXW1UBIbaCYqFdMWPF/8Lf10/1dUdtuAuZ44Krdj/n1eYIt/20gs2HZoKA==
+rifm@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/rifm/-/rifm-0.11.0.tgz#817a3f3319f2c3461ca42630dfe9f0c5cb84288b"
+  integrity sha512-h1bkVl1n69e7hYErPZF1rdhq6mTeUKecSsfimo++caU/gkAje5M8wepyKVaoQ8oLSgoC1L/2EGCr+vYAYgaM3A==
 
 rimraf@2.6.3:
   version "2.6.3"


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

This PR closes #1667 

## Description
@oliviertassinari we will not be able to expose [`Stack`](https://twitter.com/neoziro/status/1253044558784540673) API because we need to pass ref there :( Do you have any other ideas? 
I came up with rendering textfields in `React.Fragment`. TBD

So for now `renderInput` for `DateRange` will looks like

```jsx
    <DateRangePicker
      value={selectedDate}
      onChange={date => handleDateChange(date)}
      renderInput={(startProps, endProps) => (
        <>
          <TextField {...startProps} />
          <DateRangeDelimiter> to </DateRangeDelimiter>
          <TextField {...endProps} />
        </>
      )}
    />
```

## Breaking changes
* Rename `KeyboardButtonProps` => `OpenPickerButtonProps` (should have been done in #1696)
* For `DateRangePicker` new `renderInput` prop have the following signature
```tsx
<DateRangePicker
  renderInput={(startProps, endProps) => (
     <>
        <TextField {...startProps} />
        <DateRangeDelimiter> to </DateRangeDelimiter>
        <TextField {...endProps} />
     </>
   )}
/>