### PR TITLE
Clean up overrides.ts

### DIFF
--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -845,7 +845,7 @@
     },
     "renderInput": {
       "defaultValue": null,
-      "description": "Render input component. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\nrenderInput={props => <TextField {...props} />}\n````",
+      "description": "Render input component. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\rrenderInput={props => <TextField {...props} />}\r````",
       "name": "renderInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -985,7 +985,7 @@
     },
     "dateAdapter": {
       "defaultValue": null,
-      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\n```",
+      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\r\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\r\n```",
       "name": "dateAdapter",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/withDateAdapterProp.tsx",
@@ -1621,7 +1621,7 @@
     },
     "renderInput": {
       "defaultValue": null,
-      "description": "Render input component. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\nrenderInput={props => <TextField {...props} />}\n````",
+      "description": "Render input component. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\rrenderInput={props => <TextField {...props} />}\r````",
       "name": "renderInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -1761,7 +1761,7 @@
     },
     "dateAdapter": {
       "defaultValue": null,
-      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\n```",
+      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\r\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\r\n```",
       "name": "dateAdapter",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/withDateAdapterProp.tsx",
@@ -2721,7 +2721,7 @@
     },
     "renderInput": {
       "defaultValue": null,
-      "description": "Render input component. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\nrenderInput={props => <TextField {...props} />}\n````",
+      "description": "Render input component. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\rrenderInput={props => <TextField {...props} />}\r````",
       "name": "renderInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -2861,7 +2861,7 @@
     },
     "dateAdapter": {
       "defaultValue": null,
-      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\n```",
+      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\r\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\r\n```",
       "name": "dateAdapter",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/withDateAdapterProp.tsx",
@@ -3641,7 +3641,7 @@
     },
     "renderInput": {
       "defaultValue": null,
-      "description": "Render input component for date range. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\n<DateRangePicker\nrenderInput={(startProps, endProps) => (\n<>\n<TextField {...startProps} />\n<Typography> to <Typography>\n<TextField {...endProps} />\n</>;\n)}\n/>\n````",
+      "description": "Render input component for date range. Where `props` – [TextField](https://material-ui.com/api/text-field/#textfield-api) component props\n@example ```jsx\r<DateRangePicker\rrenderInput={(startProps, endProps) => (\r<>\r<TextField {...startProps} />\r<Typography> to <Typography>\r<TextField {...endProps} />\r</>;\r)}\r/>\r````",
       "name": "renderInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/DateRangePicker/DateRangePickerInput.tsx",
@@ -3820,7 +3820,7 @@
     },
     "dateAdapter": {
       "defaultValue": null,
-      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\n```",
+      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\r\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\r\n```",
       "name": "dateAdapter",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/withDateAdapterProp.tsx",

--- a/lib/src/DatePicker/DatePickerToolbar.tsx
+++ b/lib/src/DatePicker/DatePickerToolbar.tsx
@@ -18,7 +18,7 @@ export const useStyles = makeStyles(
       top: 4,
     },
   },
-  { name: 'MuiPickersDatePickerToolbar' }
+  { name: 'PrivateDatePickerToolbar' }
 );
 
 export const DatePickerToolbar: React.FC<ToolbarComponentProps> = ({

--- a/lib/src/DatePicker/DatePickerToolbar.tsx
+++ b/lib/src/DatePicker/DatePickerToolbar.tsx
@@ -18,7 +18,7 @@ export const useStyles = makeStyles(
       top: 4,
     },
   },
-  { name: 'MuiPickersDatePickerRoot' }
+  { name: 'MuiPickersDatePickerToolbar' }
 );
 
 export const DatePickerToolbar: React.FC<ToolbarComponentProps> = ({

--- a/lib/src/DateRangePicker/DateRangePickerDay.tsx
+++ b/lib/src/DateRangePicker/DateRangePickerDay.tsx
@@ -93,7 +93,7 @@ const useStyles = makeStyles(
     rangeIntervalDayPreviewStart: {},
     rangeIntervalDayPreviewEnd: {},
   }),
-  { name: 'MuiPickersDateRangeDay' }
+  { name: 'PrivateDateRangeDay' }
 );
 
 export const PureDateRangeDay = ({

--- a/lib/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/lib/src/DateRangePicker/DateRangePickerInput.tsx
@@ -26,7 +26,7 @@ export const useStyles = makeStyles(
       },
     },
   }),
-  { name: 'MuiPickersDateRangePickerInput' }
+  { name: 'PrivateDateRangePickerInput' }
 );
 
 export interface ExportedDateRangePickerInputProps {

--- a/lib/src/DateRangePicker/DateRangePickerToolbar.tsx
+++ b/lib/src/DateRangePicker/DateRangePickerToolbar.tsx
@@ -17,7 +17,7 @@ export const useStyles = makeStyles(
       display: 'flex',
     },
   },
-  { name: 'MuiPickersDateRangePickerToolbar' }
+  { name: 'PrivateDateRangePickerToolbar' }
 );
 
 interface DateRangePickerToolbarProps

--- a/lib/src/DateRangePicker/DateRangePickerToolbar.tsx
+++ b/lib/src/DateRangePicker/DateRangePickerToolbar.tsx
@@ -17,7 +17,7 @@ export const useStyles = makeStyles(
       display: 'flex',
     },
   },
-  { name: 'MuiPickersDatePickerRoot' }
+  { name: 'MuiPickersDateRangePickerToolbar' }
 );
 
 interface DateRangePickerToolbarProps

--- a/lib/src/DateRangePicker/DateRangePickerViewDesktop.tsx
+++ b/lib/src/DateRangePicker/DateRangePickerViewDesktop.tsx
@@ -52,7 +52,7 @@ export const useStyles = makeStyles(
       justifyContent: 'space-between',
     },
   }),
-  { name: 'MuiPickersDesktopDateRangeCalendar' }
+  { name: 'PrivateDateRangePickerViewDesktop' }
 );
 
 function getCalendarsArray(calendars: ExportedDesktopDateRangeCalendarProps['calendars']) {

--- a/lib/src/DateTimePicker/DateTimePickerTabs.tsx
+++ b/lib/src/DateTimePicker/DateTimePickerTabs.tsx
@@ -44,7 +44,7 @@ export const useStyles = makeStyles(
       },
     };
   },
-  { name: 'MuiPickerDTTabs' }
+  { name: 'MuiPickersDateTimePickerTabs' }
 );
 
 export const DateTimePickerTabs: React.SFC<DateTimePickerTabsProps> = ({

--- a/lib/src/DateTimePicker/DateTimePickerTabs.tsx
+++ b/lib/src/DateTimePicker/DateTimePickerTabs.tsx
@@ -44,7 +44,7 @@ export const useStyles = makeStyles(
       },
     };
   },
-  { name: 'MuiPickersDateTimePickerTabs' }
+  { name: 'PrivateDateTimePickerTabs' }
 );
 
 export const DateTimePickerTabs: React.SFC<DateTimePickerTabsProps> = ({

--- a/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -34,7 +34,7 @@ export const useStyles = makeStyles(
       right: 8,
     },
   }),
-  { name: 'MuiPickerDTToolbar' }
+  { name: 'MuiPickersDateTimePickerToolbar' }
 );
 
 export const DateTimePickerToolbar: React.FC<ToolbarComponentProps> = ({

--- a/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -34,7 +34,7 @@ export const useStyles = makeStyles(
       right: 8,
     },
   }),
-  { name: 'MuiPickersDateTimePickerToolbar' }
+  { name: 'PrivateDateTimePickerToolbar' }
 );
 
 export const DateTimePickerToolbar: React.FC<ToolbarComponentProps> = ({

--- a/lib/src/Picker/Picker.tsx
+++ b/lib/src/Picker/Picker.tsx
@@ -77,7 +77,7 @@ export const useStyles = makeStyles(
       padding: '0 8px',
     },
   },
-  { name: 'MuiPickersBasePicker' }
+  { name: 'MuiBasePicker' }
 );
 
 const MobileKeyboardTextFieldProps = { fullWidth: true };

--- a/lib/src/_shared/ArrowSwitcher.tsx
+++ b/lib/src/_shared/ArrowSwitcher.tsx
@@ -50,7 +50,7 @@ export const useStyles = makeStyles(
       visibility: 'hidden',
     },
   }),
-  { name: 'MuiPickersArrowSwitcher' }
+  { name: 'PrivateArrowSwitcher' }
 );
 
 const PureArrowSwitcher: React.FC<ArrowSwitcherProps> = ({

--- a/lib/src/_shared/ModalDialog.tsx
+++ b/lib/src/_shared/ModalDialog.tsx
@@ -53,7 +53,7 @@ export const useStyles = makeStyles(
       },
     },
   },
-  { name: 'MuiPickersModal' }
+  { name: 'PrivateModalDialog' }
 );
 
 export const ModalDialog: React.FC<ModalDialogProps> = ({

--- a/lib/src/_shared/PickerToolbar.tsx
+++ b/lib/src/_shared/PickerToolbar.tsx
@@ -39,7 +39,7 @@ export const useStyles = makeStyles(
       },
     };
   },
-  { name: 'MuiPickersToolbar' }
+  { name: 'PrivateToolbar' }
 );
 
 interface PickerToolbarProps

--- a/lib/src/_shared/ToolbarButton.tsx
+++ b/lib/src/_shared/ToolbarButton.tsx
@@ -22,7 +22,7 @@ export const useStyles = makeStyles(
       textTransform: 'none',
     },
   },
-  { name: 'MuiPickersToolbarButton' }
+  { name: 'PrivateToolbarButton' }
 );
 
 export const ToolbarButton: React.FunctionComponent<ToolbarButtonProps> = ({

--- a/lib/src/_shared/ToolbarText.tsx
+++ b/lib/src/_shared/ToolbarText.tsx
@@ -26,7 +26,7 @@ export const useStyles = makeStyles(
       },
     };
   },
-  { name: 'MuiPickersToolbarText' }
+  { name: 'PrivateToolbarText' }
 );
 
 const ToolbarText: React.FC<ToolbarTextProps> = ({

--- a/lib/src/typings/overrides.ts
+++ b/lib/src/typings/overrides.ts
@@ -17,37 +17,10 @@ type Classes<T> = Partial<
 >;
 
 export interface MuiPickersOverrides {
-  MuiArrowSwitcher?: Classes<typeof import('../_shared/ArrowSwitcher').useStyles>;
-  MuiBasePickerStyles?: Classes<typeof import('../Picker/Picker').useStyles>;
+  MuiBasePicker?: Classes<typeof import('../Picker/Picker').useStyles>;
   MuiCalendar?: Classes<typeof import('../views/Calendar/Calendar').useStyles>;
-  MuiCalendarHeader?: Classes<typeof import('../views/Calendar/CalendarHeader').useStyles>;
   MuiCalendarView?: Classes<typeof import('../views/Calendar/CalendarView').useStyles>;
   MuiClock?: Classes<typeof import('../views/Clock/Clock').useStyles>;
-  MuiClockNumber?: Classes<typeof import('../views/Clock/ClockNumber').useStyles>;
-  MuiClockPointer?: Classes<typeof import('../views/Clock/ClockPointer').styles>;
-  MuiDatePickerToolbar?: Classes<typeof import('../DatePicker/DatePickerToolbar').useStyles>;
-  MuiDateRangePickerInput?: Classes<
-    typeof import('../DateRangePicker/DateRangePickerInput').useStyles
-  >;
-  MuiDateRangePickerToolbar?: Classes<
-    typeof import('../DateRangePicker/DateRangePickerToolbar').useStyles
-  >;
-  MuiDateRangePickerViewDesktop?: Classes<
-    typeof import('../DateRangePicker/DateRangePickerViewDesktop').useStyles
-  >;
-  MuiDateTimePickerTabs?: Classes<typeof import('../DateTimePicker/DateTimePickerTabs').useStyles>;
-  MuiDateTimePickerToolbar?: Classes<
-    typeof import('../DateTimePicker/DateTimePickerToolbar').useStyles
-  >;
+  MuiClockView?: Classes<typeof import('../views/Clock/ClockView').useStyles>;
   MuiDay?: Classes<typeof import('../views/Calendar/Day').useStyles>;
-  MuiModal?: Classes<typeof import('../_shared/ModalDialog').useStyles>;
-  MuiMonth?: Classes<typeof import('../views/Calendar/Month').useStyles>;
-  MuiMonthSelection?: Classes<typeof import('../views/Calendar/MonthSelection').useStyles>;
-  MuiSlideTransition?: Classes<typeof import('../views/Calendar/SlideTransition').useStyles>;
-  MuiTimePickerToolbar?: Classes<typeof import('../TimePicker/TimePickerToolbar').useStyles>;
-  MuiToolbar?: Classes<typeof import('../_shared/PickerToolbar').useStyles>;
-  MuiToolbarButton?: Classes<typeof import('../_shared/ToolbarButton').useStyles>;
-  MuiToolbarText?: Classes<typeof import('../_shared/ToolbarText').useStyles>;
-  MuiYear?: Classes<typeof import('../views/Calendar/Year').useStyles>;
-  MuiYearSelection?: Classes<typeof import('../views/Calendar/YearSelection').useStyles>;
 }

--- a/lib/src/typings/overrides.ts
+++ b/lib/src/typings/overrides.ts
@@ -1,26 +1,4 @@
-import { useStyles as DayStyles } from '../views/Calendar/Day';
-import { useStyles as ClockStyles } from '../views/Clock/Clock';
-import { useStyles as MuiBasePickerStyles } from '../Picker/Picker';
-import { useStyles as ModalDialogStyles } from '../_shared/ModalDialog';
-import { useStyles as CalendarStyles } from '../views/Calendar/Calendar';
-import { useStyles as MuiPickersYearStyles } from '../views/Calendar/Year';
-import { styles as ClockPointerStyles } from '../views/Clock/ClockPointer';
-import { useStyles as ToolbarButtonStyles } from '../_shared/ToolbarButton';
-import { useStyles as PickerToolbarStyles } from '../_shared/PickerToolbar';
-import { useStyles as ClockNumberStyles } from '../views/Clock/ClockNumber';
-import { useStyles as MuiPickersMonthStyles } from '../views/Calendar/Month';
-import { useStyles as CalendarViewStyles } from '../views/Calendar/CalendarView';
-import { useStyles as DTTabsStyles } from '../DateTimePicker/DateTimePickerTabs';
-import { useStyles as MuiPickersToolbarTextStyles } from '../_shared/ToolbarText';
-import { useStyles as DatePickerRootStyles } from '../DatePicker/DatePickerToolbar';
-import { useStyles as CalendarHeaderStyles } from '../views/Calendar/CalendarHeader';
 import { StyleRules, StyleRulesCallback } from '@material-ui/core/styles/withStyles';
-import { useStyles as DTHeaderStyles } from '../DateTimePicker/DateTimePickerToolbar';
-import { useStyles as TimePickerToolbarStyles } from '../TimePicker/TimePickerToolbar';
-import { useStyles as SlideTransitionStyles } from '../views/Calendar/SlideTransition';
-import { useStyles as MuiPickersYearSelectionStyles } from '../views/Calendar/YearSelection';
-import { useStyles as MuiPickersMonthSelectionStyles } from '../views/Calendar/MonthSelection';
-import { useStyles as MuiPickerDTToolbarStyles } from '../DateTimePicker/DateTimePickerToolbar';
 
 type StylesHook<C extends string> = (props?: any) => Record<C, string>;
 
@@ -39,34 +17,37 @@ type Classes<T> = Partial<
 >;
 
 export interface MuiPickersOverrides {
-  MuiPickersDay?: Classes<typeof DayStyles>;
-  MuiPickerDTHeader?: Classes<typeof DTHeaderStyles>;
-  MuiPickerDTTabs?: Classes<typeof DTTabsStyles>;
-  MuiPickersCalendar?: Classes<typeof CalendarStyles>;
-  MuiPickersCalendarView?: Classes<typeof CalendarViewStyles>;
-  MuiPickersCalendarHeader?: Classes<typeof CalendarHeaderStyles>;
-  MuiPickersSlideTransition?: Classes<typeof SlideTransitionStyles>;
-  MuiPickersYearSelection?: Classes<typeof MuiPickersYearSelectionStyles>;
-  MuiPickersYear?: Classes<typeof MuiPickersYearStyles>;
-  MuiPickersMonthSelection?: Classes<typeof MuiPickersMonthSelectionStyles>;
-  MuiPickersMonth?: Classes<typeof MuiPickersMonthStyles>;
-  MuiPickersTimePickerToolbar?: Classes<typeof TimePickerToolbarStyles>;
-  MuiPickersClock?: Classes<typeof ClockStyles>;
-  MuiPickersClockNumber?: Classes<typeof ClockNumberStyles>;
-  MuiPickersClockPointer?: Classes<typeof ClockPointerStyles>;
-  MuiPickersModal?: Classes<typeof ModalDialogStyles>;
-  MuiPickersToolbar?: Classes<typeof PickerToolbarStyles>;
-  MuiPickersToolbarButton?: Classes<typeof ToolbarButtonStyles>;
-  MuiPickersToolbarText?: Classes<typeof MuiPickersToolbarTextStyles>;
-  MuiPickersDatePickerRoot?: Classes<typeof DatePickerRootStyles>;
-  MuiPickerDTToolbar?: Classes<typeof MuiPickerDTToolbarStyles>;
-  MuiBasePickerStyles?: Classes<typeof MuiBasePickerStyles>;
-  // consider using inline import type notation
-  MuiPickersDesktopDateRangeCalendar?: Classes<
-    typeof import('../DateRangePicker/DateRangePickerViewDesktop').useStyles
-  >;
-  MuiPickersArrowSwitcher?: Classes<typeof import('../_shared/ArrowSwitcher').useStyles>;
-  MuiPickersDateRangePickerInput?: Classes<
+  MuiArrowSwitcher?: Classes<typeof import('../_shared/ArrowSwitcher').useStyles>;
+  MuiBasePickerStyles?: Classes<typeof import('../Picker/Picker').useStyles>;
+  MuiCalendar?: Classes<typeof import('../views/Calendar/Calendar').useStyles>;
+  MuiCalendarHeader?: Classes<typeof import('../views/Calendar/CalendarHeader').useStyles>;
+  MuiCalendarView?: Classes<typeof import('../views/Calendar/CalendarView').useStyles>;
+  MuiClock?: Classes<typeof import('../views/Clock/Clock').useStyles>;
+  MuiClockNumber?: Classes<typeof import('../views/Clock/ClockNumber').useStyles>;
+  MuiClockPointer?: Classes<typeof import('../views/Clock/ClockPointer').styles>;
+  MuiDatePickerToolbar?: Classes<typeof import('../DatePicker/DatePickerToolbar').useStyles>;
+  MuiDateRangePickerInput?: Classes<
     typeof import('../DateRangePicker/DateRangePickerInput').useStyles
   >;
+  MuiDateRangePickerToolbar?: Classes<
+    typeof import('../DateRangePicker/DateRangePickerToolbar').useStyles
+  >;
+  MuiDateRangePickerViewDesktop?: Classes<
+    typeof import('../DateRangePicker/DateRangePickerViewDesktop').useStyles
+  >;
+  MuiDateTimePickerTabs?: Classes<typeof import('../DateTimePicker/DateTimePickerTabs').useStyles>;
+  MuiDateTimePickerToolbar?: Classes<
+    typeof import('../DateTimePicker/DateTimePickerToolbar').useStyles
+  >;
+  MuiDay?: Classes<typeof import('../views/Calendar/Day').useStyles>;
+  MuiModal?: Classes<typeof import('../_shared/ModalDialog').useStyles>;
+  MuiMonth?: Classes<typeof import('../views/Calendar/Month').useStyles>;
+  MuiMonthSelection?: Classes<typeof import('../views/Calendar/MonthSelection').useStyles>;
+  MuiSlideTransition?: Classes<typeof import('../views/Calendar/SlideTransition').useStyles>;
+  MuiTimePickerToolbar?: Classes<typeof import('../TimePicker/TimePickerToolbar').useStyles>;
+  MuiToolbar?: Classes<typeof import('../_shared/PickerToolbar').useStyles>;
+  MuiToolbarButton?: Classes<typeof import('../_shared/ToolbarButton').useStyles>;
+  MuiToolbarText?: Classes<typeof import('../_shared/ToolbarText').useStyles>;
+  MuiYear?: Classes<typeof import('../views/Calendar/Year').useStyles>;
+  MuiYearSelection?: Classes<typeof import('../views/Calendar/YearSelection').useStyles>;
 }

--- a/lib/src/views/Calendar/CalendarHeader.tsx
+++ b/lib/src/views/Calendar/CalendarHeader.tsx
@@ -71,7 +71,7 @@ export const useStyles = makeStyles(
       marginRight: 4,
     },
   }),
-  { name: 'MuiPickersCalendarHeader' }
+  { name: 'PrivateCalendarHeader' }
 );
 
 function getSwitchingViewAriaText(view: DatePickerView) {

--- a/lib/src/views/Calendar/CalendarView.tsx
+++ b/lib/src/views/Calendar/CalendarView.tsx
@@ -69,7 +69,7 @@ export const useStyles = makeStyles(
       height: '100%',
     },
   },
-  { name: 'MuiPickersCalendarView' }
+  { name: 'MuiCalendarView' }
 );
 
 export const defaultReduceAnimations =

--- a/lib/src/views/Calendar/Day.tsx
+++ b/lib/src/views/Calendar/Day.tsx
@@ -67,7 +67,7 @@ export const useStyles = makeStyles(
       // need for overrides
     },
   }),
-  { name: 'MuiPickersDay' }
+  { name: 'MuiDay' }
 );
 
 export interface DayProps extends ExtendMui<ButtonBaseProps> {

--- a/lib/src/views/Calendar/FadeTransitionGroup.tsx
+++ b/lib/src/views/Calendar/FadeTransitionGroup.tsx
@@ -39,7 +39,7 @@ export const useStyles = makeStyles(
       },
     };
   },
-  { name: 'MuiPickersFadeTransition' }
+  { name: 'PrivateFadeTransitionGroup' }
 );
 
 export const FadeTransitionGroup: React.FC<FadeTransitionProps> = ({

--- a/lib/src/views/Calendar/Month.tsx
+++ b/lib/src/views/Calendar/Month.tsx
@@ -37,7 +37,7 @@ export const useStyles = makeStyles(
       color: theme.palette.text.hint,
     },
   }),
-  { name: 'MuiPickersMonth' }
+  { name: 'PrivateMonth' }
 );
 
 export const Month: React.FC<MonthProps> = ({

--- a/lib/src/views/Calendar/MonthSelection.tsx
+++ b/lib/src/views/Calendar/MonthSelection.tsx
@@ -24,7 +24,7 @@ export const useStyles = makeStyles(
       alignContent: 'stretch',
     },
   },
-  { name: 'MuiPickersMonthSelection' }
+  { name: 'PrivateMonthSelection' }
 );
 
 export const MonthSelection: React.FC<MonthSelectionProps> = ({

--- a/lib/src/views/Calendar/SlideTransition.tsx
+++ b/lib/src/views/Calendar/SlideTransition.tsx
@@ -64,7 +64,7 @@ export const useStyles = makeStyles(
       },
     };
   },
-  { name: 'MuiPickersSlideTransition' }
+  { name: 'PrivateSlideTransition' }
 );
 
 export const SlideTransition: React.SFC<SlideTransitionProps> = ({

--- a/lib/src/views/Calendar/Year.tsx
+++ b/lib/src/views/Calendar/Year.tsx
@@ -52,7 +52,7 @@ export const useStyles = makeStyles(
       color: theme.palette.text.hint,
     },
   }),
-  { name: 'MuiPickersYear' }
+  { name: 'PrivateYear' }
 );
 
 export const Year: React.FC<YearProps> = ({

--- a/lib/src/views/Calendar/YearSelection.tsx
+++ b/lib/src/views/Calendar/YearSelection.tsx
@@ -29,7 +29,7 @@ export const useStyles = makeStyles(
       height: '100%',
     },
   },
-  { name: 'MuiPickersYearSelection' }
+  { name: 'PrivateYearSelection' }
 );
 
 export const YearSelection: React.FC<YearSelectionProps> = ({

--- a/lib/src/views/Clock/Clock.tsx
+++ b/lib/src/views/Clock/Clock.tsx
@@ -89,7 +89,7 @@ export const useStyles = makeStyles(
     },
   }),
   {
-    name: 'MuiPickersClock',
+    name: 'MuiClock',
   }
 );
 

--- a/lib/src/views/Clock/ClockNumber.tsx
+++ b/lib/src/views/Clock/ClockNumber.tsx
@@ -75,7 +75,7 @@ export const useStyles = makeStyles(
       },
     };
   },
-  { name: 'MuiPickersClockNumber' }
+  { name: 'PrivateClockNumber' }
 );
 
 export const ClockNumber: React.FC<ClockNumberProps> = ({

--- a/lib/src/views/Clock/ClockPointer.tsx
+++ b/lib/src/views/Clock/ClockPointer.tsx
@@ -102,5 +102,5 @@ export const styles = (theme: Theme) =>
   });
 
 export default withStyles(styles, {
-  name: 'MuiPickersClockPointer',
+  name: 'PrivateClockPointer',
 })(ClockPointer as React.ComponentType<ClockPointerProps>);

--- a/lib/src/views/Clock/ClockView.tsx
+++ b/lib/src/views/Clock/ClockView.tsx
@@ -74,7 +74,7 @@ export const useStyles = makeStyles(
       top: 8,
     },
   }),
-  { name: 'MuiPickersClockView' }
+  { name: 'MuiClockView' }
 );
 
 const getHoursAriaText = (hour: string) => `${hour} hours`;

--- a/lib/src/wrappers/StaticWrapper.tsx
+++ b/lib/src/wrappers/StaticWrapper.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles(
       backgroundColor: theme.palette.background.paper,
     },
   }),
-  { name: 'MuiPickersStaticWrapper' }
+  { name: 'PrivateStaticWrapper' }
 );
 
 export interface StaticWrapperProps {


### PR DESCRIPTION
- Use inline imports to make the file less verbose and easier to change in the future.
- Sort alphabetically instead of arbitrarily.
- Name styles consistently like `MuiPickers<component_name>`, except for `MuiPickersBasePicker`.