### PR TITLE
[docs] Fix minDate error message in Formik example

### DIFF
--- a/docs/pages/guides/FormikOurValidation.example.tsx
+++ b/docs/pages/guides/FormikOurValidation.example.tsx
@@ -42,7 +42,7 @@ function DatePickerField({
             break;
 
           case 'minDate':
-            form.setFieldError(name, `Date should not be after ${format(maxDate, 'P')}`);
+            form.setFieldError(name, `Date should not be before ${format(minDate, 'P')}`);
             break;
 
           case 'shouldDisableDate':


### PR DESCRIPTION
The error handling introduced in `v4.0.0-alpha6` is amazing! There's just a tiny issue in the Formik example: the `minDate` message is the same as the `maxDate` one. This PR addresses it.