### PR TITLE
[test] CI should fail for new warnings

### DIFF
--- a/lib/src/__tests__/setup.js
+++ b/lib/src/__tests__/setup.js
@@ -36,3 +36,24 @@ console.error = (...args) => {
     throw new Error(message);
   }
 };
+
+// Convert any console warning into a thrown error
+const warn = console.warn;
+console.warn = (...args) => {
+  warn.apply(console, args);
+  if (args[0] instanceof Error) {
+    throw args[0];
+  } else {
+    // combine multi args into a string
+    const message = args
+      .map(value => {
+        if (typeof value === 'object') {
+          return JSON.stringify(value);
+        } else {
+          return value;
+        }
+      })
+      .join(' ');
+    throw new Error(message);
+  }
+};


### PR DESCRIPTION
This objective of this pull request is to surface an issue we will face with https://github.com/mui-org/material-ui/issues/19706. The equivalent behavior can be found in https://github.com/mui-org/material-ui/blob/14834adf8c07cd043a169cb486097f2363bbe420/test/utils/consoleError.js.

Waiting for #1776 to be resolved. 