### PR TITLE
[core] Small changes

### DIFF
--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -294,7 +294,7 @@
   "DatePicker": {
     "views": {
       "defaultValue": null,
-      "description": "Array of views to show",
+      "description": "Array of views to show.",
       "name": "views",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/Picker/SharedPickerProps.tsx",
@@ -307,7 +307,7 @@
     },
     "openTo": {
       "defaultValue": null,
-      "description": "First view to show",
+      "description": "First view to show.",
       "name": "openTo",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/Picker/SharedPickerProps.tsx",
@@ -454,7 +454,7 @@
     },
     "shouldDisableDate": {
       "defaultValue": null,
-      "description": "Disable specific date",
+      "description": "Disable specific date.",
       "name": "shouldDisableDate",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/date-utils.ts",
@@ -469,7 +469,7 @@
       "defaultValue": {
         "value": "Date(1900-01-01)"
       },
-      "description": "Min selectable date",
+      "description": "Min selectable date.",
       "name": "minDate",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/date-utils.ts",
@@ -484,7 +484,7 @@
       "defaultValue": {
         "value": "Date(2100-01-01)"
       },
-      "description": "Max selectable date",
+      "description": "Max selectable date.",
       "name": "maxDate",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/date-utils.ts",
@@ -499,7 +499,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Disable past dates",
+      "description": "Disable past dates.",
       "name": "disablePast",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/date-utils.ts",
@@ -514,7 +514,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Disable future dates",
+      "description": "Disable future dates.",
       "name": "disableFuture",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/date-utils.ts",
@@ -1299,7 +1299,7 @@
     },
     "views": {
       "defaultValue": null,
-      "description": "Array of views to show",
+      "description": "Array of views to show.",
       "name": "views",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/Picker/SharedPickerProps.tsx",
@@ -1312,7 +1312,7 @@
     },
     "openTo": {
       "defaultValue": null,
-      "description": "First view to show",
+      "description": "First view to show.",
       "name": "openTo",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/Picker/SharedPickerProps.tsx",
@@ -1955,7 +1955,7 @@
     },
     "views": {
       "defaultValue": null,
-      "description": "Array of views to show",
+      "description": "Array of views to show.",
       "name": "views",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/Picker/SharedPickerProps.tsx",
@@ -1968,7 +1968,7 @@
     },
     "openTo": {
       "defaultValue": null,
-      "description": "First view to show",
+      "description": "First view to show.",
       "name": "openTo",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/Picker/SharedPickerProps.tsx",
@@ -2229,7 +2229,7 @@
     },
     "shouldDisableDate": {
       "defaultValue": null,
-      "description": "Disable specific date",
+      "description": "Disable specific date.",
       "name": "shouldDisableDate",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/date-utils.ts",
@@ -2244,7 +2244,7 @@
       "defaultValue": {
         "value": "Date(1900-01-01)"
       },
-      "description": "Min selectable date",
+      "description": "Min selectable date.",
       "name": "minDate",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/date-utils.ts",
@@ -2259,7 +2259,7 @@
       "defaultValue": {
         "value": "Date(2100-01-01)"
       },
-      "description": "Max selectable date",
+      "description": "Max selectable date.",
       "name": "maxDate",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/date-utils.ts",
@@ -2274,7 +2274,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Disable past dates",
+      "description": "Disable past dates.",
       "name": "disablePast",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/date-utils.ts",
@@ -2289,7 +2289,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Disable future dates",
+      "description": "Disable future dates.",
       "name": "disableFuture",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/date-utils.ts",
@@ -3085,7 +3085,7 @@
     },
     "shouldDisableDate": {
       "defaultValue": null,
-      "description": "Disable specific date",
+      "description": "Disable specific date.",
       "name": "shouldDisableDate",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/date-utils.ts",
@@ -3100,7 +3100,7 @@
       "defaultValue": {
         "value": "Date(1900-01-01)"
       },
-      "description": "Min selectable date",
+      "description": "Min selectable date.",
       "name": "minDate",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/date-utils.ts",
@@ -3115,7 +3115,7 @@
       "defaultValue": {
         "value": "Date(2100-01-01)"
       },
-      "description": "Max selectable date",
+      "description": "Max selectable date.",
       "name": "maxDate",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/date-utils.ts",
@@ -3130,7 +3130,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Disable past dates",
+      "description": "Disable past dates.",
       "name": "disablePast",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/date-utils.ts",
@@ -3145,7 +3145,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Disable future dates",
+      "description": "Disable future dates.",
       "name": "disableFuture",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/date-utils.ts",

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -105,7 +105,7 @@
     },
     "PopoverProps": {
       "defaultValue": null,
-      "description": "Popover props passed to material-ui Popover",
+      "description": "Popover props passed to material-ui Popover.",
       "name": "PopoverProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopWrapper.tsx",
@@ -135,7 +135,7 @@
   "DesktopWrapper": {
     "PopoverProps": {
       "defaultValue": null,
-      "description": "Popover props passed to material-ui Popover",
+      "description": "Popover props passed to material-ui Popover.",
       "name": "PopoverProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopWrapper.tsx",
@@ -251,7 +251,7 @@
     },
     "PopperProps": {
       "defaultValue": null,
-      "description": "Popper props passed to material-ui [Popper](https://material-ui.com/api/popper/#popper-api)",
+      "description": "Popper props passed to material-ui [Popper](https://material-ui.com/api/popper/#popper-api).",
       "name": "PopperProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopPopperWrapper.tsx",
@@ -264,7 +264,7 @@
     },
     "TransitionComponent": {
       "defaultValue": null,
-      "description": "Custom component for [transition](https://material-ui.com/components/transitions/#transitioncomponent-prop)",
+      "description": "Custom component for [transition](https://material-ui.com/components/transitions/#transitioncomponent-prop).",
       "name": "TransitionComponent",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopPopperWrapper.tsx",
@@ -335,7 +335,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Disable highlighting today date with a circle",
+      "description": "Disable highlighting today date with a circle.",
       "name": "disableHighlightToday",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -350,7 +350,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Display disabled dates outside the current month",
+      "description": "Display disabled dates outside the current month.",
       "name": "showDaysOutsideCurrentMonth",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -441,7 +441,7 @@
     },
     "getViewSwitchingButtonText": {
       "defaultValue": null,
-      "description": "Get aria-label text for switching between views button",
+      "description": "Get aria-label text for switching between views button.",
       "name": "getViewSwitchingButtonText",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/CalendarHeader.tsx",
@@ -527,7 +527,7 @@
     },
     "reduceAnimations": {
       "defaultValue": null,
-      "description": "Disable heavy animations @default /(android)/i.test(window.navigator.userAgent)",
+      "description": "Disable heavy animations @default /(android)/i.test(window.navigator.userAgent).",
       "name": "reduceAnimations",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/CalendarView.tsx",
@@ -540,7 +540,7 @@
     },
     "onMonthChange": {
       "defaultValue": null,
-      "description": "Callback firing on month change. Return promise to render spinner till it will not be resolved",
+      "description": "Callback firing on month change. Return promise to render spinner till it will not be resolved.",
       "name": "onMonthChange",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/CalendarView.tsx",
@@ -553,7 +553,7 @@
     },
     "renderDay": {
       "defaultValue": null,
-      "description": "Custom renderer for day. Check [DayComponentProps api](https://material-ui-pickers.dev/api/Day)",
+      "description": "Custom renderer for day. Check [DayComponentProps api](https://material-ui-pickers.dev/api/Day).",
       "name": "renderDay",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -568,7 +568,7 @@
       "defaultValue": {
         "value": "currentWrapper !== 'static'"
       },
-      "description": "Enables keyboard listener for moving between days in calendar",
+      "description": "Enables keyboard listener for moving between days in calendar.",
       "name": "allowKeyboardControl",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -581,7 +581,7 @@
     },
     "loadingIndicator": {
       "defaultValue": null,
-      "description": "Custom loading indicator",
+      "description": "Custom loading indicator.",
       "name": "loadingIndicator",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -594,7 +594,7 @@
     },
     "onYearChange": {
       "defaultValue": null,
-      "description": "Callback firing on year change",
+      "description": "Callback firing on year change.",
       "name": "onYearChange",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/YearSelection.tsx",
@@ -607,7 +607,7 @@
     },
     "shouldDisableYear": {
       "defaultValue": null,
-      "description": "Disable specific years dynamically. Works like `shouldDisableDate` but for year selection view.",
+      "description": "Disable specific years dynamically.\nWorks like `shouldDisableDate` but for year selection view..",
       "name": "shouldDisableYear",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/YearSelection.tsx",
@@ -620,7 +620,7 @@
     },
     "value": {
       "defaultValue": null,
-      "description": "Picker value",
+      "description": "Picker value.",
       "name": "value",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -633,7 +633,7 @@
     },
     "onChange": {
       "defaultValue": null,
-      "description": "onChange callback",
+      "description": "onChange callback.",
       "name": "onChange",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -648,7 +648,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Auto accept date on selection",
+      "description": "Auto accept date on selection.",
       "name": "autoOk",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -661,7 +661,7 @@
     },
     "inputFormat": {
       "defaultValue": null,
-      "description": "Format string",
+      "description": "Format string.",
       "name": "inputFormat",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -674,7 +674,7 @@
     },
     "disabled": {
       "defaultValue": null,
-      "description": "Disable picker and text field",
+      "description": "Disable picker and text field.",
       "name": "disabled",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -687,7 +687,7 @@
     },
     "readOnly": {
       "defaultValue": null,
-      "description": "Make picker read only",
+      "description": "Make picker read only.",
       "name": "readOnly",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -700,7 +700,7 @@
     },
     "onAccept": {
       "defaultValue": null,
-      "description": "Callback fired when date is accepted",
+      "description": "Callback fired when date is accepted.",
       "name": "onAccept",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -713,7 +713,7 @@
     },
     "onOpen": {
       "defaultValue": null,
-      "description": "On open callback",
+      "description": "On open callback.",
       "name": "onOpen",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -726,7 +726,7 @@
     },
     "onClose": {
       "defaultValue": null,
-      "description": "On close callback",
+      "description": "On close callback.",
       "name": "onClose",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -739,7 +739,7 @@
     },
     "open": {
       "defaultValue": null,
-      "description": "Controlled picker open state",
+      "description": "Controlled picker open state.",
       "name": "open",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -752,7 +752,7 @@
     },
     "showToolbar": {
       "defaultValue": null,
-      "description": "Show toolbar even in desktop mode",
+      "description": "Show toolbar even in desktop mode.",
       "name": "showToolbar",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -765,7 +765,7 @@
     },
     "orientation": {
       "defaultValue": null,
-      "description": "Force rendering in particular orientation",
+      "description": "Force rendering in particular orientation.",
       "name": "orientation",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -778,7 +778,7 @@
     },
     "ToolbarComponent": {
       "defaultValue": null,
-      "description": "Component that will replace default toolbar renderer",
+      "description": "Component that will replace default toolbar renderer.",
       "name": "ToolbarComponent",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -793,7 +793,7 @@
       "defaultValue": {
         "value": "\"SELECT DATE\""
       },
-      "description": "Mobile picker title, displaying in the toolbar",
+      "description": "Mobile picker title, displaying in the toolbar.",
       "name": "toolbarTitle",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -808,7 +808,7 @@
       "defaultValue": {
         "value": "\"–\""
       },
-      "description": "Mobile picker date value placeholder, displaying if `value` === `null`",
+      "description": "Mobile picker date value placeholder, displaying if `value` === `null`.",
       "name": "toolbarPlaceholder",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -821,7 +821,7 @@
     },
     "toolbarFormat": {
       "defaultValue": null,
-      "description": "Date format, that is displaying in toolbar",
+      "description": "Date format, that is displaying in toolbar.",
       "name": "toolbarFormat",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -834,7 +834,7 @@
     },
     "className": {
       "defaultValue": null,
-      "description": "className applied to the root component",
+      "description": "className applied to the root component.",
       "name": "className",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -873,7 +873,7 @@
     },
     "openPickerIcon": {
       "defaultValue": null,
-      "description": "Icon displaying for open picker button",
+      "description": "Icon displaying for open picker button.",
       "name": "openPickerIcon",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -888,7 +888,7 @@
       "defaultValue": {
         "value": "/\\dap/gi"
       },
-      "description": "Regular expression to detect \"accepted\" symbols",
+      "description": "Regular expression to detect \"accepted\" symbols.",
       "name": "acceptRegex",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -901,7 +901,7 @@
     },
     "InputAdornmentProps": {
       "defaultValue": null,
-      "description": "Props to pass to keyboard input adornment",
+      "description": "Props to pass to keyboard input adornment.",
       "name": "InputAdornmentProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -914,7 +914,7 @@
     },
     "OpenPickerButtonProps": {
       "defaultValue": null,
-      "description": "Props to pass to keyboard adornment button",
+      "description": "Props to pass to keyboard adornment button.",
       "name": "OpenPickerButtonProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -927,7 +927,7 @@
     },
     "rifmFormatter": {
       "defaultValue": null,
-      "description": "Custom formatter to be passed into Rifm component",
+      "description": "Custom formatter to be passed into Rifm component.",
       "name": "rifmFormatter",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -942,7 +942,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Do not render open picker button (renders only text field with validation)",
+      "description": "Do not render open picker button (renders only text field with validation).",
       "name": "disableOpenPicker",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -957,7 +957,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format",
+      "description": "Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.",
       "name": "disableMaskedInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -1101,7 +1101,7 @@
     },
     "PopperProps": {
       "defaultValue": null,
-      "description": "Popper props passed to material-ui [Popper](https://material-ui.com/api/popper/#popper-api)",
+      "description": "Popper props passed to material-ui [Popper](https://material-ui.com/api/popper/#popper-api).",
       "name": "PopperProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopPopperWrapper.tsx",
@@ -1114,7 +1114,7 @@
     },
     "TransitionComponent": {
       "defaultValue": null,
-      "description": "Custom component for [transition](https://material-ui.com/components/transitions/#transitioncomponent-prop)",
+      "description": "Custom component for [transition](https://material-ui.com/components/transitions/#transitioncomponent-prop).",
       "name": "TransitionComponent",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopPopperWrapper.tsx",
@@ -1142,7 +1142,7 @@
     },
     "PopoverProps": {
       "defaultValue": null,
-      "description": "Popover props passed to material-ui Popover",
+      "description": "Popover props passed to material-ui Popover.",
       "name": "PopoverProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopWrapper.tsx",
@@ -1157,7 +1157,7 @@
       "defaultValue": {
         "value": "\""
       },
-      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@media (pointer: fine)\"\n@example \"\n@media (min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
+      "description": "CSS media query when `Mobile` mode will be changed to `Desktop`.\n@media (pointer: fine)\"\n@example \"\n@media (min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
       "name": "desktopModeMediaQuery",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",
@@ -1232,7 +1232,7 @@
     },
     "minTime": {
       "defaultValue": null,
-      "description": "Min time acceptable time. For input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified.",
+      "description": "Min time acceptable time.\nFor input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified.",
       "name": "minTime",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/time-utils.ts",
@@ -1245,7 +1245,7 @@
     },
     "maxTime": {
       "defaultValue": null,
-      "description": "Max time acceptable time. For input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified.",
+      "description": "Max time acceptable time.\nFor input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified.",
       "name": "maxTime",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/time-utils.ts",
@@ -1258,7 +1258,7 @@
     },
     "shouldDisableTime": {
       "defaultValue": null,
-      "description": "Dynamically check if time is disabled or not. If returns `false` appropriate time point will ot be acceptable.",
+      "description": "Dynamically check if time is disabled or not.\nIf returns `false` appropriate time point will ot be acceptable.",
       "name": "shouldDisableTime",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/time-utils.ts",
@@ -1325,7 +1325,7 @@
     },
     "value": {
       "defaultValue": null,
-      "description": "Picker value",
+      "description": "Picker value.",
       "name": "value",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1338,7 +1338,7 @@
     },
     "onChange": {
       "defaultValue": null,
-      "description": "onChange callback",
+      "description": "onChange callback.",
       "name": "onChange",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1353,7 +1353,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Auto accept date on selection",
+      "description": "Auto accept date on selection.",
       "name": "autoOk",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1366,7 +1366,7 @@
     },
     "inputFormat": {
       "defaultValue": null,
-      "description": "Format string",
+      "description": "Format string.",
       "name": "inputFormat",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1379,7 +1379,7 @@
     },
     "disabled": {
       "defaultValue": null,
-      "description": "Disable picker and text field",
+      "description": "Disable picker and text field.",
       "name": "disabled",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1392,7 +1392,7 @@
     },
     "readOnly": {
       "defaultValue": null,
-      "description": "Make picker read only",
+      "description": "Make picker read only.",
       "name": "readOnly",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1405,7 +1405,7 @@
     },
     "onAccept": {
       "defaultValue": null,
-      "description": "Callback fired when date is accepted",
+      "description": "Callback fired when date is accepted.",
       "name": "onAccept",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1418,7 +1418,7 @@
     },
     "onOpen": {
       "defaultValue": null,
-      "description": "On open callback",
+      "description": "On open callback.",
       "name": "onOpen",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1431,7 +1431,7 @@
     },
     "onClose": {
       "defaultValue": null,
-      "description": "On close callback",
+      "description": "On close callback.",
       "name": "onClose",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1444,7 +1444,7 @@
     },
     "open": {
       "defaultValue": null,
-      "description": "Controlled picker open state",
+      "description": "Controlled picker open state.",
       "name": "open",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1457,7 +1457,7 @@
     },
     "showToolbar": {
       "defaultValue": null,
-      "description": "Show toolbar even in desktop mode",
+      "description": "Show toolbar even in desktop mode.",
       "name": "showToolbar",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1470,7 +1470,7 @@
     },
     "orientation": {
       "defaultValue": null,
-      "description": "Force rendering in particular orientation",
+      "description": "Force rendering in particular orientation.",
       "name": "orientation",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1483,7 +1483,7 @@
     },
     "ToolbarComponent": {
       "defaultValue": null,
-      "description": "Component that will replace default toolbar renderer",
+      "description": "Component that will replace default toolbar renderer.",
       "name": "ToolbarComponent",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1498,7 +1498,7 @@
       "defaultValue": {
         "value": "\"SELECT DATE\""
       },
-      "description": "Mobile picker title, displaying in the toolbar",
+      "description": "Mobile picker title, displaying in the toolbar.",
       "name": "toolbarTitle",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1513,7 +1513,7 @@
       "defaultValue": {
         "value": "\"–\""
       },
-      "description": "Mobile picker date value placeholder, displaying if `value` === `null`",
+      "description": "Mobile picker date value placeholder, displaying if `value` === `null`.",
       "name": "toolbarPlaceholder",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1526,7 +1526,7 @@
     },
     "toolbarFormat": {
       "defaultValue": null,
-      "description": "Date format, that is displaying in toolbar",
+      "description": "Date format, that is displaying in toolbar.",
       "name": "toolbarFormat",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1539,7 +1539,7 @@
     },
     "className": {
       "defaultValue": null,
-      "description": "className applied to the root component",
+      "description": "className applied to the root component.",
       "name": "className",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -1578,7 +1578,7 @@
     },
     "openPickerIcon": {
       "defaultValue": null,
-      "description": "Icon displaying for open picker button",
+      "description": "Icon displaying for open picker button.",
       "name": "openPickerIcon",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -1593,7 +1593,7 @@
       "defaultValue": {
         "value": "/\\dap/gi"
       },
-      "description": "Regular expression to detect \"accepted\" symbols",
+      "description": "Regular expression to detect \"accepted\" symbols.",
       "name": "acceptRegex",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -1606,7 +1606,7 @@
     },
     "InputAdornmentProps": {
       "defaultValue": null,
-      "description": "Props to pass to keyboard input adornment",
+      "description": "Props to pass to keyboard input adornment.",
       "name": "InputAdornmentProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -1619,7 +1619,7 @@
     },
     "OpenPickerButtonProps": {
       "defaultValue": null,
-      "description": "Props to pass to keyboard adornment button",
+      "description": "Props to pass to keyboard adornment button.",
       "name": "OpenPickerButtonProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -1632,7 +1632,7 @@
     },
     "rifmFormatter": {
       "defaultValue": null,
-      "description": "Custom formatter to be passed into Rifm component",
+      "description": "Custom formatter to be passed into Rifm component.",
       "name": "rifmFormatter",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -1647,7 +1647,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Do not render open picker button (renders only text field with validation)",
+      "description": "Do not render open picker button (renders only text field with validation).",
       "name": "disableOpenPicker",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -1662,7 +1662,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format",
+      "description": "Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.",
       "name": "disableMaskedInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -1806,7 +1806,7 @@
     },
     "PopperProps": {
       "defaultValue": null,
-      "description": "Popper props passed to material-ui [Popper](https://material-ui.com/api/popper/#popper-api)",
+      "description": "Popper props passed to material-ui [Popper](https://material-ui.com/api/popper/#popper-api).",
       "name": "PopperProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopPopperWrapper.tsx",
@@ -1819,7 +1819,7 @@
     },
     "TransitionComponent": {
       "defaultValue": null,
-      "description": "Custom component for [transition](https://material-ui.com/components/transitions/#transitioncomponent-prop)",
+      "description": "Custom component for [transition](https://material-ui.com/components/transitions/#transitioncomponent-prop).",
       "name": "TransitionComponent",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopPopperWrapper.tsx",
@@ -1847,7 +1847,7 @@
     },
     "PopoverProps": {
       "defaultValue": null,
-      "description": "Popover props passed to material-ui Popover",
+      "description": "Popover props passed to material-ui Popover.",
       "name": "PopoverProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopWrapper.tsx",
@@ -1862,7 +1862,7 @@
       "defaultValue": {
         "value": "\""
       },
-      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@media (pointer: fine)\"\n@example \"\n@media (min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
+      "description": "CSS media query when `Mobile` mode will be changed to `Desktop`.\n@media (pointer: fine)\"\n@example \"\n@media (min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
       "name": "desktopModeMediaQuery",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",
@@ -1877,7 +1877,7 @@
   "DateTimePicker": {
     "hideTabs": {
       "defaultValue": null,
-      "description": "To show tabs",
+      "description": "To show tabs.",
       "name": "hideTabs",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/DateTimePicker/DateTimePicker.tsx",
@@ -1890,7 +1890,7 @@
     },
     "dateRangeIcon": {
       "defaultValue": null,
-      "description": "Date tab icon",
+      "description": "Date tab icon.",
       "name": "dateRangeIcon",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/DateTimePicker/DateTimePicker.tsx",
@@ -1903,7 +1903,7 @@
     },
     "timeIcon": {
       "defaultValue": null,
-      "description": "Time tab icon",
+      "description": "Time tab icon.",
       "name": "timeIcon",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/DateTimePicker/DateTimePicker.tsx",
@@ -1916,7 +1916,7 @@
     },
     "minDateTime": {
       "defaultValue": null,
-      "description": "Minimal selectable moment of time with binding to date, to set min time in each day use `minTime`",
+      "description": "Minimal selectable moment of time with binding to date, to set min time in each day use `minTime`.",
       "name": "minDateTime",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/DateTimePicker/DateTimePicker.tsx",
@@ -1929,7 +1929,7 @@
     },
     "maxDateTime": {
       "defaultValue": null,
-      "description": "Minimal selectable moment of time with binding to date, to set max time in each day use `maxTime`",
+      "description": "Minimal selectable moment of time with binding to date, to set max time in each day use `maxTime`.",
       "name": "maxDateTime",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/DateTimePicker/DateTimePicker.tsx",
@@ -1942,7 +1942,7 @@
     },
     "toolbarFormat": {
       "defaultValue": null,
-      "description": "Date format, that is displaying in toolbar\nDate format, that is displaying in toolbar",
+      "description": "Date format, that is displaying in toolbar.\nDate format, that is displaying in toolbar.",
       "name": "toolbarFormat",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/DateTimePicker/DateTimePicker.tsx",
@@ -2054,7 +2054,7 @@
     },
     "minTime": {
       "defaultValue": null,
-      "description": "Min time acceptable time. For input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified.",
+      "description": "Min time acceptable time.\nFor input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified.",
       "name": "minTime",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/time-utils.ts",
@@ -2067,7 +2067,7 @@
     },
     "maxTime": {
       "defaultValue": null,
-      "description": "Max time acceptable time. For input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified.",
+      "description": "Max time acceptable time.\nFor input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified.",
       "name": "maxTime",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/time-utils.ts",
@@ -2080,7 +2080,7 @@
     },
     "shouldDisableTime": {
       "defaultValue": null,
-      "description": "Dynamically check if time is disabled or not. If returns `false` appropriate time point will ot be acceptable.",
+      "description": "Dynamically check if time is disabled or not.\nIf returns `false` appropriate time point will ot be acceptable.",
       "name": "shouldDisableTime",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/time-utils.ts",
@@ -2110,7 +2110,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Disable highlighting today date with a circle",
+      "description": "Disable highlighting today date with a circle.",
       "name": "disableHighlightToday",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -2125,7 +2125,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Display disabled dates outside the current month",
+      "description": "Display disabled dates outside the current month.",
       "name": "showDaysOutsideCurrentMonth",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -2216,7 +2216,7 @@
     },
     "getViewSwitchingButtonText": {
       "defaultValue": null,
-      "description": "Get aria-label text for switching between views button",
+      "description": "Get aria-label text for switching between views button.",
       "name": "getViewSwitchingButtonText",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/CalendarHeader.tsx",
@@ -2302,7 +2302,7 @@
     },
     "reduceAnimations": {
       "defaultValue": null,
-      "description": "Disable heavy animations @default /(android)/i.test(window.navigator.userAgent)",
+      "description": "Disable heavy animations @default /(android)/i.test(window.navigator.userAgent).",
       "name": "reduceAnimations",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/CalendarView.tsx",
@@ -2315,7 +2315,7 @@
     },
     "onMonthChange": {
       "defaultValue": null,
-      "description": "Callback firing on month change. Return promise to render spinner till it will not be resolved",
+      "description": "Callback firing on month change. Return promise to render spinner till it will not be resolved.",
       "name": "onMonthChange",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/CalendarView.tsx",
@@ -2328,7 +2328,7 @@
     },
     "renderDay": {
       "defaultValue": null,
-      "description": "Custom renderer for day. Check [DayComponentProps api](https://material-ui-pickers.dev/api/Day)",
+      "description": "Custom renderer for day. Check [DayComponentProps api](https://material-ui-pickers.dev/api/Day).",
       "name": "renderDay",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -2341,7 +2341,7 @@
     },
     "loadingIndicator": {
       "defaultValue": null,
-      "description": "Custom loading indicator",
+      "description": "Custom loading indicator.",
       "name": "loadingIndicator",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -2354,7 +2354,7 @@
     },
     "onYearChange": {
       "defaultValue": null,
-      "description": "Callback firing on year change",
+      "description": "Callback firing on year change.",
       "name": "onYearChange",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/YearSelection.tsx",
@@ -2367,7 +2367,7 @@
     },
     "shouldDisableYear": {
       "defaultValue": null,
-      "description": "Disable specific years dynamically. Works like `shouldDisableDate` but for year selection view.",
+      "description": "Disable specific years dynamically.\nWorks like `shouldDisableDate` but for year selection view..",
       "name": "shouldDisableYear",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/YearSelection.tsx",
@@ -2380,7 +2380,7 @@
     },
     "value": {
       "defaultValue": null,
-      "description": "Picker value",
+      "description": "Picker value.",
       "name": "value",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2393,7 +2393,7 @@
     },
     "onChange": {
       "defaultValue": null,
-      "description": "onChange callback",
+      "description": "onChange callback.",
       "name": "onChange",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2408,7 +2408,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Auto accept date on selection",
+      "description": "Auto accept date on selection.",
       "name": "autoOk",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2421,7 +2421,7 @@
     },
     "inputFormat": {
       "defaultValue": null,
-      "description": "Format string",
+      "description": "Format string.",
       "name": "inputFormat",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2434,7 +2434,7 @@
     },
     "disabled": {
       "defaultValue": null,
-      "description": "Disable picker and text field",
+      "description": "Disable picker and text field.",
       "name": "disabled",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2447,7 +2447,7 @@
     },
     "readOnly": {
       "defaultValue": null,
-      "description": "Make picker read only",
+      "description": "Make picker read only.",
       "name": "readOnly",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2460,7 +2460,7 @@
     },
     "onAccept": {
       "defaultValue": null,
-      "description": "Callback fired when date is accepted",
+      "description": "Callback fired when date is accepted.",
       "name": "onAccept",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2473,7 +2473,7 @@
     },
     "onOpen": {
       "defaultValue": null,
-      "description": "On open callback",
+      "description": "On open callback.",
       "name": "onOpen",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2486,7 +2486,7 @@
     },
     "onClose": {
       "defaultValue": null,
-      "description": "On close callback",
+      "description": "On close callback.",
       "name": "onClose",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2499,7 +2499,7 @@
     },
     "open": {
       "defaultValue": null,
-      "description": "Controlled picker open state",
+      "description": "Controlled picker open state.",
       "name": "open",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2512,7 +2512,7 @@
     },
     "showToolbar": {
       "defaultValue": null,
-      "description": "Show toolbar even in desktop mode",
+      "description": "Show toolbar even in desktop mode.",
       "name": "showToolbar",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2525,7 +2525,7 @@
     },
     "orientation": {
       "defaultValue": null,
-      "description": "Force rendering in particular orientation",
+      "description": "Force rendering in particular orientation.",
       "name": "orientation",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2538,7 +2538,7 @@
     },
     "ToolbarComponent": {
       "defaultValue": null,
-      "description": "Component that will replace default toolbar renderer",
+      "description": "Component that will replace default toolbar renderer.",
       "name": "ToolbarComponent",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2553,7 +2553,7 @@
       "defaultValue": {
         "value": "\"SELECT DATE\""
       },
-      "description": "Mobile picker title, displaying in the toolbar",
+      "description": "Mobile picker title, displaying in the toolbar.",
       "name": "toolbarTitle",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2568,7 +2568,7 @@
       "defaultValue": {
         "value": "\"–\""
       },
-      "description": "Mobile picker date value placeholder, displaying if `value` === `null`",
+      "description": "Mobile picker date value placeholder, displaying if `value` === `null`.",
       "name": "toolbarPlaceholder",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2581,7 +2581,7 @@
     },
     "className": {
       "defaultValue": null,
-      "description": "className applied to the root component",
+      "description": "className applied to the root component.",
       "name": "className",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -2620,7 +2620,7 @@
     },
     "openPickerIcon": {
       "defaultValue": null,
-      "description": "Icon displaying for open picker button",
+      "description": "Icon displaying for open picker button.",
       "name": "openPickerIcon",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -2635,7 +2635,7 @@
       "defaultValue": {
         "value": "/\\dap/gi"
       },
-      "description": "Regular expression to detect \"accepted\" symbols",
+      "description": "Regular expression to detect \"accepted\" symbols.",
       "name": "acceptRegex",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -2648,7 +2648,7 @@
     },
     "InputAdornmentProps": {
       "defaultValue": null,
-      "description": "Props to pass to keyboard input adornment",
+      "description": "Props to pass to keyboard input adornment.",
       "name": "InputAdornmentProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -2661,7 +2661,7 @@
     },
     "OpenPickerButtonProps": {
       "defaultValue": null,
-      "description": "Props to pass to keyboard adornment button",
+      "description": "Props to pass to keyboard adornment button.",
       "name": "OpenPickerButtonProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -2674,7 +2674,7 @@
     },
     "rifmFormatter": {
       "defaultValue": null,
-      "description": "Custom formatter to be passed into Rifm component",
+      "description": "Custom formatter to be passed into Rifm component.",
       "name": "rifmFormatter",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -2689,7 +2689,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Do not render open picker button (renders only text field with validation)",
+      "description": "Do not render open picker button (renders only text field with validation).",
       "name": "disableOpenPicker",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -2704,7 +2704,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format",
+      "description": "Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.",
       "name": "disableMaskedInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -2848,7 +2848,7 @@
     },
     "PopperProps": {
       "defaultValue": null,
-      "description": "Popper props passed to material-ui [Popper](https://material-ui.com/api/popper/#popper-api)",
+      "description": "Popper props passed to material-ui [Popper](https://material-ui.com/api/popper/#popper-api).",
       "name": "PopperProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopPopperWrapper.tsx",
@@ -2861,7 +2861,7 @@
     },
     "TransitionComponent": {
       "defaultValue": null,
-      "description": "Custom component for [transition](https://material-ui.com/components/transitions/#transitioncomponent-prop)",
+      "description": "Custom component for [transition](https://material-ui.com/components/transitions/#transitioncomponent-prop).",
       "name": "TransitionComponent",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopPopperWrapper.tsx",
@@ -2889,7 +2889,7 @@
     },
     "PopoverProps": {
       "defaultValue": null,
-      "description": "Popover props passed to material-ui Popover",
+      "description": "Popover props passed to material-ui Popover.",
       "name": "PopoverProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopWrapper.tsx",
@@ -2904,7 +2904,7 @@
       "defaultValue": {
         "value": "\""
       },
-      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@media (pointer: fine)\"\n@example \"\n@media (min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
+      "description": "CSS media query when `Mobile` mode will be changed to `Desktop`.\n@media (pointer: fine)\"\n@example \"\n@media (min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
       "name": "desktopModeMediaQuery",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",
@@ -2966,7 +2966,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Disable highlighting today date with a circle",
+      "description": "Disable highlighting today date with a circle.",
       "name": "disableHighlightToday",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -2981,7 +2981,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Display disabled dates outside the current month",
+      "description": "Display disabled dates outside the current month.",
       "name": "showDaysOutsideCurrentMonth",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -3072,7 +3072,7 @@
     },
     "getViewSwitchingButtonText": {
       "defaultValue": null,
-      "description": "Get aria-label text for switching between views button",
+      "description": "Get aria-label text for switching between views button.",
       "name": "getViewSwitchingButtonText",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/CalendarHeader.tsx",
@@ -3158,7 +3158,7 @@
     },
     "reduceAnimations": {
       "defaultValue": null,
-      "description": "Disable heavy animations @default /(android)/i.test(window.navigator.userAgent)",
+      "description": "Disable heavy animations @default /(android)/i.test(window.navigator.userAgent).",
       "name": "reduceAnimations",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/CalendarView.tsx",
@@ -3171,7 +3171,7 @@
     },
     "onMonthChange": {
       "defaultValue": null,
-      "description": "Callback firing on month change. Return promise to render spinner till it will not be resolved",
+      "description": "Callback firing on month change. Return promise to render spinner till it will not be resolved.",
       "name": "onMonthChange",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/CalendarView.tsx",
@@ -3184,7 +3184,7 @@
     },
     "renderDay": {
       "defaultValue": null,
-      "description": "Custom renderer for day. Check [DayComponentProps api](https://material-ui-pickers.dev/api/Day)",
+      "description": "Custom renderer for day. Check [DayComponentProps api](https://material-ui-pickers.dev/api/Day).",
       "name": "renderDay",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -3199,7 +3199,7 @@
       "defaultValue": {
         "value": "currentWrapper !== 'static'"
       },
-      "description": "Enables keyboard listener for moving between days in calendar",
+      "description": "Enables keyboard listener for moving between days in calendar.",
       "name": "allowKeyboardControl",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -3212,7 +3212,7 @@
     },
     "loadingIndicator": {
       "defaultValue": null,
-      "description": "Custom loading indicator",
+      "description": "Custom loading indicator.",
       "name": "loadingIndicator",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -3225,7 +3225,7 @@
     },
     "shouldDisableYear": {
       "defaultValue": null,
-      "description": "Disable specific years dynamically. Works like `shouldDisableDate` but for year selection view.",
+      "description": "Disable specific years dynamically.\nWorks like `shouldDisableDate` but for year selection view..",
       "name": "shouldDisableYear",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/YearSelection.tsx",
@@ -3253,7 +3253,7 @@
     },
     "className": {
       "defaultValue": null,
-      "description": "className applied to the root component",
+      "description": "className applied to the root component.",
       "name": "className",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3266,7 +3266,7 @@
     },
     "disabled": {
       "defaultValue": null,
-      "description": "Disable picker and text field",
+      "description": "Disable picker and text field.",
       "name": "disabled",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3281,7 +3281,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Auto accept date on selection",
+      "description": "Auto accept date on selection.",
       "name": "autoOk",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3294,7 +3294,7 @@
     },
     "inputFormat": {
       "defaultValue": null,
-      "description": "Format string",
+      "description": "Format string.",
       "name": "inputFormat",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3307,7 +3307,7 @@
     },
     "readOnly": {
       "defaultValue": null,
-      "description": "Make picker read only",
+      "description": "Make picker read only.",
       "name": "readOnly",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3320,7 +3320,7 @@
     },
     "onAccept": {
       "defaultValue": null,
-      "description": "Callback fired when date is accepted",
+      "description": "Callback fired when date is accepted.",
       "name": "onAccept",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3333,7 +3333,7 @@
     },
     "onOpen": {
       "defaultValue": null,
-      "description": "On open callback",
+      "description": "On open callback.",
       "name": "onOpen",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3346,7 +3346,7 @@
     },
     "onClose": {
       "defaultValue": null,
-      "description": "On close callback",
+      "description": "On close callback.",
       "name": "onClose",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3359,7 +3359,7 @@
     },
     "open": {
       "defaultValue": null,
-      "description": "Controlled picker open state",
+      "description": "Controlled picker open state.",
       "name": "open",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3372,7 +3372,7 @@
     },
     "showToolbar": {
       "defaultValue": null,
-      "description": "Show toolbar even in desktop mode",
+      "description": "Show toolbar even in desktop mode.",
       "name": "showToolbar",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3385,7 +3385,7 @@
     },
     "orientation": {
       "defaultValue": null,
-      "description": "Force rendering in particular orientation",
+      "description": "Force rendering in particular orientation.",
       "name": "orientation",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3398,7 +3398,7 @@
     },
     "ToolbarComponent": {
       "defaultValue": null,
-      "description": "Component that will replace default toolbar renderer",
+      "description": "Component that will replace default toolbar renderer.",
       "name": "ToolbarComponent",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3413,7 +3413,7 @@
       "defaultValue": {
         "value": "\"SELECT DATE\""
       },
-      "description": "Mobile picker title, displaying in the toolbar",
+      "description": "Mobile picker title, displaying in the toolbar.",
       "name": "toolbarTitle",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3428,7 +3428,7 @@
       "defaultValue": {
         "value": "\"–\""
       },
-      "description": "Mobile picker date value placeholder, displaying if `value` === `null`",
+      "description": "Mobile picker date value placeholder, displaying if `value` === `null`.",
       "name": "toolbarPlaceholder",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3441,7 +3441,7 @@
     },
     "toolbarFormat": {
       "defaultValue": null,
-      "description": "Date format, that is displaying in toolbar",
+      "description": "Date format, that is displaying in toolbar.",
       "name": "toolbarFormat",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3480,7 +3480,7 @@
     },
     "onChange": {
       "defaultValue": null,
-      "description": "onChange callback",
+      "description": "onChange callback.",
       "name": "onChange",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3506,7 +3506,7 @@
     },
     "value": {
       "defaultValue": null,
-      "description": "Picker value",
+      "description": "Picker value.",
       "name": "value",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/typings/BasePicker.tsx",
@@ -3519,7 +3519,7 @@
     },
     "openPickerIcon": {
       "defaultValue": null,
-      "description": "Icon displaying for open picker button",
+      "description": "Icon displaying for open picker button.",
       "name": "openPickerIcon",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -3534,7 +3534,7 @@
       "defaultValue": {
         "value": "/\\dap/gi"
       },
-      "description": "Regular expression to detect \"accepted\" symbols",
+      "description": "Regular expression to detect \"accepted\" symbols.",
       "name": "acceptRegex",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -3547,7 +3547,7 @@
     },
     "InputAdornmentProps": {
       "defaultValue": null,
-      "description": "Props to pass to keyboard input adornment",
+      "description": "Props to pass to keyboard input adornment.",
       "name": "InputAdornmentProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -3560,7 +3560,7 @@
     },
     "OpenPickerButtonProps": {
       "defaultValue": null,
-      "description": "Props to pass to keyboard adornment button",
+      "description": "Props to pass to keyboard adornment button.",
       "name": "OpenPickerButtonProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -3573,7 +3573,7 @@
     },
     "rifmFormatter": {
       "defaultValue": null,
-      "description": "Custom formatter to be passed into Rifm component",
+      "description": "Custom formatter to be passed into Rifm component.",
       "name": "rifmFormatter",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -3588,7 +3588,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Do not render open picker button (renders only text field with validation)",
+      "description": "Do not render open picker button (renders only text field with validation).",
       "name": "disableOpenPicker",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -3603,7 +3603,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format",
+      "description": "Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.",
       "name": "disableMaskedInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -3747,7 +3747,7 @@
     },
     "PopperProps": {
       "defaultValue": null,
-      "description": "Popper props passed to material-ui [Popper](https://material-ui.com/api/popper/#popper-api)",
+      "description": "Popper props passed to material-ui [Popper](https://material-ui.com/api/popper/#popper-api).",
       "name": "PopperProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopPopperWrapper.tsx",
@@ -3760,7 +3760,7 @@
     },
     "TransitionComponent": {
       "defaultValue": null,
-      "description": "Custom component for [transition](https://material-ui.com/components/transitions/#transitioncomponent-prop)",
+      "description": "Custom component for [transition](https://material-ui.com/components/transitions/#transitioncomponent-prop).",
       "name": "TransitionComponent",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopPopperWrapper.tsx",
@@ -3788,7 +3788,7 @@
     },
     "PopoverProps": {
       "defaultValue": null,
-      "description": "Popover props passed to material-ui Popover",
+      "description": "Popover props passed to material-ui Popover.",
       "name": "PopoverProps",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/DesktopWrapper.tsx",
@@ -3803,7 +3803,7 @@
       "defaultValue": {
         "value": "\""
       },
-      "description": "Css media query when `Mobile` mode will be changed to `Desktop`\n@media (pointer: fine)\"\n@example \"\n@media (min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
+      "description": "CSS media query when `Mobile` mode will be changed to `Desktop`.\n@media (pointer: fine)\"\n@example \"\n@media (min-width: 720px)\" or theme.breakpoints.up(\"sm\")",
       "name": "desktopModeMediaQuery",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/wrappers/ResponsiveWrapper.tsx",
@@ -3818,7 +3818,7 @@
   "Calendar": {
     "onChange": {
       "defaultValue": null,
-      "description": "Calendar onChange",
+      "description": "Calendar onChange.",
       "name": "onChange",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -3831,7 +3831,7 @@
     },
     "renderDay": {
       "defaultValue": null,
-      "description": "Custom renderer for day. Check [DayComponentProps api](https://material-ui-pickers.dev/api/Day)",
+      "description": "Custom renderer for day. Check [DayComponentProps api](https://material-ui-pickers.dev/api/Day).",
       "name": "renderDay",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -3846,7 +3846,7 @@
       "defaultValue": {
         "value": "currentWrapper !== 'static'"
       },
-      "description": "Enables keyboard listener for moving between days in calendar",
+      "description": "Enables keyboard listener for moving between days in calendar.",
       "name": "allowKeyboardControl",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -3859,7 +3859,7 @@
     },
     "loadingIndicator": {
       "defaultValue": null,
-      "description": "Custom loading indicator",
+      "description": "Custom loading indicator.",
       "name": "loadingIndicator",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Calendar.tsx",
@@ -3874,7 +3874,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Disable highlighting today date with a circle",
+      "description": "Disable highlighting today date with a circle.",
       "name": "disableHighlightToday",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -3889,7 +3889,7 @@
       "defaultValue": {
         "value": "false"
       },
-      "description": "Display disabled dates outside the current month",
+      "description": "Display disabled dates outside the current month.",
       "name": "showDaysOutsideCurrentMonth",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -3904,7 +3904,7 @@
   "Day": {
     "day": {
       "defaultValue": null,
-      "description": "The date to show",
+      "description": "The date to show.",
       "name": "day",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -3919,7 +3919,7 @@
       "defaultValue": {
         "value": false
       },
-      "description": "Is focused by keyboard navigation",
+      "description": "Is focused by keyboard navigation.",
       "name": "focused",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -3934,7 +3934,7 @@
       "defaultValue": {
         "value": false
       },
-      "description": "Can be focused by tabbing in",
+      "description": "Can be focused by tabbing in.",
       "name": "focusable",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -3947,7 +3947,7 @@
     },
     "inCurrentMonth": {
       "defaultValue": null,
-      "description": "Is day in current month",
+      "description": "Is day in current month.",
       "name": "inCurrentMonth",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -3960,7 +3960,7 @@
     },
     "isAnimating": {
       "defaultValue": null,
-      "description": "Is switching month animation going on right now",
+      "description": "Is switching month animation going on right now.",
       "name": "isAnimating",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -3990,7 +3990,7 @@
       "defaultValue": {
         "value": false
       },
-      "description": "Disabled?",
+      "description": "Disabled?.",
       "name": "disabled",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -4018,7 +4018,7 @@
     },
     "allowKeyboardControl": {
       "defaultValue": null,
-      "description": "Is keyboard control and focus management enabled",
+      "description": "Is keyboard control and focus management enabled.",
       "name": "allowKeyboardControl",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -4033,7 +4033,7 @@
       "defaultValue": {
         "value": false
       },
-      "description": "Disable margin between days, useful for displaying range of days",
+      "description": "Disable margin between days, useful for displaying range of days.",
       "name": "disableMargin",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -4048,7 +4048,7 @@
       "defaultValue": {
         "value": false
       },
-      "description": "Display disabled dates outside the current month",
+      "description": "Display disabled dates outside the current month.",
       "name": "showDaysOutsideCurrentMonth",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -4063,7 +4063,7 @@
       "defaultValue": {
         "value": false
       },
-      "description": "Disable highlighting today date with a circle",
+      "description": "Disable highlighting today date with a circle.",
       "name": "disableHighlightToday",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/Day.tsx",
@@ -4078,7 +4078,7 @@
   "ClockView": {
     "date": {
       "defaultValue": null,
-      "description": "Selected date",
+      "description": "Selected date.",
       "name": "date",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Clock/ClockView.tsx",
@@ -4091,7 +4091,7 @@
     },
     "type": {
       "defaultValue": null,
-      "description": "Clock type",
+      "description": "Clock type.",
       "name": "type",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Clock/ClockView.tsx",
@@ -4104,7 +4104,7 @@
     },
     "onDateChange": {
       "defaultValue": null,
-      "description": "On change date without moving between views",
+      "description": "On change date without moving between views.",
       "name": "onDateChange",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Clock/ClockView.tsx",
@@ -4117,7 +4117,7 @@
     },
     "onChange": {
       "defaultValue": null,
-      "description": "On change callback",
+      "description": "On change callback.",
       "name": "onChange",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Clock/ClockView.tsx",
@@ -4132,7 +4132,7 @@
       "defaultValue": {
         "value": null
       },
-      "description": "Get clock number aria-text for hours",
+      "description": "Get clock number aria-text for hours.",
       "name": "getHoursClockNumberText",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Clock/ClockView.tsx",
@@ -4147,7 +4147,7 @@
       "defaultValue": {
         "value": null
       },
-      "description": "Get clock number aria-text for minutes",
+      "description": "Get clock number aria-text for minutes.",
       "name": "getMinutesClockNumberText",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Clock/ClockView.tsx",
@@ -4162,7 +4162,7 @@
       "defaultValue": {
         "value": null
       },
-      "description": "Get clock number aria-text for seconds",
+      "description": "Get clock number aria-text for seconds.",
       "name": "getSecondsClockNumberText",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Clock/ClockView.tsx",
@@ -4235,7 +4235,7 @@
     },
     "minTime": {
       "defaultValue": null,
-      "description": "Min time acceptable time. For input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified.",
+      "description": "Min time acceptable time.\nFor input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified.",
       "name": "minTime",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/time-utils.ts",
@@ -4248,7 +4248,7 @@
     },
     "maxTime": {
       "defaultValue": null,
-      "description": "Max time acceptable time. For input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified.",
+      "description": "Max time acceptable time.\nFor input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified.",
       "name": "maxTime",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/time-utils.ts",
@@ -4261,7 +4261,7 @@
     },
     "shouldDisableTime": {
       "defaultValue": null,
-      "description": "Dynamically check if time is disabled or not. If returns `false` appropriate time point will ot be acceptable.",
+      "description": "Dynamically check if time is disabled or not.\nIf returns `false` appropriate time point will ot be acceptable.",
       "name": "shouldDisableTime",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_helpers/time-utils.ts",

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -526,8 +526,10 @@
       }
     },
     "reduceAnimations": {
-      "defaultValue": null,
-      "description": "Disable heavy animations @default /(android)/i.test(window.navigator.userAgent).",
+      "defaultValue": {
+        "value": "/(android)/i.test(window.navigator.userAgent)."
+      },
+      "description": "Disable heavy animations.",
       "name": "reduceAnimations",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/CalendarView.tsx",
@@ -2301,8 +2303,10 @@
       }
     },
     "reduceAnimations": {
-      "defaultValue": null,
-      "description": "Disable heavy animations @default /(android)/i.test(window.navigator.userAgent).",
+      "defaultValue": {
+        "value": "/(android)/i.test(window.navigator.userAgent)."
+      },
+      "description": "Disable heavy animations.",
       "name": "reduceAnimations",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/CalendarView.tsx",
@@ -3157,8 +3161,10 @@
       }
     },
     "reduceAnimations": {
-      "defaultValue": null,
-      "description": "Disable heavy animations @default /(android)/i.test(window.navigator.userAgent).",
+      "defaultValue": {
+        "value": "/(android)/i.test(window.navigator.userAgent)."
+      },
+      "description": "Disable heavy animations.",
       "name": "reduceAnimations",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/views/Calendar/CalendarView.tsx",

--- a/lib/src/DateTimePicker/DateTimePicker.tsx
+++ b/lib/src/DateTimePicker/DateTimePicker.tsx
@@ -19,17 +19,29 @@ export interface DateTimePickerProps
     ValidationProps<DateAndTimeValidationError, ParsableDate>,
     ExportedClockViewProps,
     ExportedCalendarViewProps {
-  /** To show tabs */
+  /**
+   * To show tabs.
+   */
   hideTabs?: boolean;
-  /** Date tab icon */
+  /**
+   * Date tab icon.
+   */
   dateRangeIcon?: React.ReactNode;
-  /** Time tab icon */
+  /**
+   * Time tab icon.
+   */
   timeIcon?: React.ReactNode;
-  /** Minimal selectable moment of time with binding to date, to set min time in each day use `minTime` */
+  /**
+   * Minimal selectable moment of time with binding to date, to set min time in each day use `minTime`.
+   */
   minDateTime?: ParsableDate;
-  /** Minimal selectable moment of time with binding to date, to set max time in each day use `maxTime` */
+  /**
+   * Minimal selectable moment of time with binding to date, to set max time in each day use `maxTime`.
+   */
   maxDateTime?: ParsableDate;
-  /** Date format, that is displaying in toolbar */
+  /**
+   * Date format, that is displaying in toolbar.
+   */
   toolbarFormat?: string;
 }
 

--- a/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -11,7 +11,7 @@ import { ToolbarComponentProps } from '../Picker/Picker';
 import { WrapperVariantContext } from '../wrappers/WrapperVariantContext';
 
 export const useStyles = makeStyles(
-  _ => ({
+  {
     toolbar: {
       paddingLeft: 16,
       paddingRight: 16,
@@ -35,7 +35,7 @@ export const useStyles = makeStyles(
       top: 8,
       right: 8,
     },
-  }),
+  },
   { name: 'MuiPickerDTToolbar' }
 );
 

--- a/lib/src/Picker/Picker.tsx
+++ b/lib/src/Picker/Picker.tsx
@@ -22,23 +22,23 @@ export type ToolbarComponentProps<
   TDate = MaterialUiPickersDate,
   TView extends AnyPickerView = AnyPickerView
 > = CalendarAndClockProps & {
-  views: TView[];
-  openView: TView;
+  ampmInClock?: boolean;
   date: TDate;
-  setOpenView: (view: TView) => void;
-  onChange: (date: TDate, isFinish?: boolean) => void;
-  toolbarTitle?: React.ReactNode;
-  toolbarPlaceholder?: React.ReactNode;
-  toolbarFormat?: string;
+  dateRangeIcon?: React.ReactNode;
+  getMobileKeyboardInputViewButtonText?: () => string;
   // TODO move out, cause it is DateTimePickerOnly
   hideTabs?: boolean;
-  dateRangeIcon?: React.ReactNode;
-  timeIcon?: React.ReactNode;
   isLandscape: boolean;
-  ampmInClock?: boolean;
   isMobileKeyboardViewOpen: boolean;
+  onChange: (date: TDate, isFinish?: boolean) => void;
+  openView: TView;
+  setOpenView: (view: TView) => void;
+  timeIcon?: React.ReactNode;
   toggleMobileKeyboardView: () => void;
-  getMobileKeyboardInputViewButtonText?: () => string;
+  toolbarFormat?: string;
+  toolbarPlaceholder?: React.ReactNode;
+  toolbarTitle?: React.ReactNode;
+  views: TView[];
 };
 
 export interface ExportedPickerProps<TView extends AnyPickerView>

--- a/lib/src/Picker/SharedPickerProps.tsx
+++ b/lib/src/Picker/SharedPickerProps.tsx
@@ -33,9 +33,11 @@ export interface SharedPickerProps<
 
 export interface WithViewsProps<T extends AnyPickerView> {
   /**
-   * Array of views to show
+   * Array of views to show.
    */
   views?: T[];
-  /** First view to show */
+  /**
+   * First view to show.
+   */
   openTo?: T;
 }

--- a/lib/src/Picker/makePickerWithState.tsx
+++ b/lib/src/Picker/makePickerWithState.tsx
@@ -20,9 +20,13 @@ export type AllPickerProps<T, TWrapper extends SomeWrapper = SomeWrapper> = T &
   ExtendWrapper<TWrapper>;
 
 export interface MakePickerOptions<T extends unknown> {
-  /** Hook that running validation for the `value` and input */
+  /**
+   * Hook that running validation for the `value` and input.
+   */
   useValidation: (value: ParsableDate, props: T) => string | null;
-  /** Intercept props to override or inject default props specifically for picker */
+  /**
+   * Intercept props to override or inject default props specifically for picker.
+   */
   useInterceptProps: (props: AllPickerProps<T>) => AllPickerProps<T> & { inputFormat: string };
   DefaultToolbarComponent: React.ComponentType<ToolbarComponentProps>;
 }

--- a/lib/src/__tests__/DatePicker.test.tsx
+++ b/lib/src/__tests__/DatePicker.test.tsx
@@ -222,7 +222,7 @@ describe('e2e - DatePicker month change async', () => {
   });
 });
 
-test('Custom toolbar component', () => {
+it('Custom toolbar component', () => {
   const component = mount(
     <MobileDatePicker
       renderInput={props => <TextField {...props} />}
@@ -237,7 +237,7 @@ test('Custom toolbar component', () => {
   expect(component.find('#custom-toolbar').length).toBe(1);
 });
 
-test('Selected date is disabled', () => {
+it('Selected date is disabled', () => {
   const component = mount(
     <MobileDatePicker
       renderInput={props => <TextField {...props} />}
@@ -262,7 +262,7 @@ test('Selected date is disabled', () => {
   ).toBe('January');
 });
 
-test('Should not add to loading queue when synchronous', () => {
+it('Should not add to loading queue when synchronous', () => {
   const component = mountPickerWithState(null as MaterialUiPickersDate, props => (
     <StaticDatePicker toolbarPlaceholder="Enter Date" {...props} />
   ));

--- a/lib/src/__tests__/DateRangePicker.test.tsx
+++ b/lib/src/__tests__/DateRangePicker.test.tsx
@@ -13,7 +13,7 @@ const defaultRangeRenderInput = (startProps: TextFieldProps, endProps: TextField
 );
 
 describe('DateRangePicker', () => {
-  test('allows select range', () => {
+  it('allows select range', () => {
     const component = mount(
       <DesktopDateRangePicker
         open
@@ -29,7 +29,7 @@ describe('DateRangePicker', () => {
     expect(component.find('[data-mui-test="DateRangeHighlight"]').length).toBe(31);
   });
 
-  test('allows disabling dates', () => {
+  it('allows disabling dates', () => {
     const component = mount(
       <DesktopDateRangePicker
         open
@@ -51,7 +51,7 @@ describe('DateRangePicker', () => {
     ).toBe(59);
   });
 
-  test('prop: calendars', () => {
+  it('prop: calendars', () => {
     const component = mount(
       <DesktopDateRangePicker
         open
@@ -69,7 +69,7 @@ describe('DateRangePicker', () => {
     expect(component.find('button[data-mui-test="DateRangeDay"]').length).toBe(90);
   });
 
-  test(`doesn't crashes if opening picker with invalid date input`, () => {
+  it(`doesn't crashes if opening picker with invalid date input`, () => {
     const component = mount(
       <DesktopDateRangePicker
         open

--- a/lib/src/__tests__/DateTimePicker.test.tsx
+++ b/lib/src/__tests__/DateTimePicker.test.tsx
@@ -105,7 +105,7 @@ describe('e2e -- Override utils using `dateAdapter`', () => {
   });
 });
 
-test('e2e - DateTimePicker empty date', () => {
+it('e2e - DateTimePicker empty date', () => {
   const component = mountPickerWithState(null as MaterialUiPickersDate, props => (
     <DateTimePicker open toolbarPlaceholder="Enter Date" {...props} />
   ));

--- a/lib/src/__tests__/Theme.test.tsx
+++ b/lib/src/__tests__/Theme.test.tsx
@@ -12,7 +12,7 @@ const theme = createMuiTheme({
   },
 });
 
-test('Should renders without crash in dark theme', () => {
+it('Should renders without crash in dark theme', () => {
   const component = mount(
     <ThemeProvider theme={theme}>
       <DateTimePicker
@@ -28,7 +28,7 @@ test('Should renders without crash in dark theme', () => {
   expect(component).toBeTruthy();
 });
 
-test('Should render component with different orientation', () => {
+it('Should render component with different orientation', () => {
   const component = mount(
     <DatePicker
       renderInput={props => <TextField {...props} />}

--- a/lib/src/__tests__/TimePicker.test.tsx
+++ b/lib/src/__tests__/TimePicker.test.tsx
@@ -258,7 +258,7 @@ describe('e2e - TimePicker time validation', () => {
   });
 });
 
-test('e2e - TimePicker empty date', () => {
+it('e2e - TimePicker empty date', () => {
   const component = mountPickerWithState(null as MaterialUiPickersDate, props => (
     <TimePicker open {...props} />
   ));

--- a/lib/src/__tests__/Validation.test.tsx
+++ b/lib/src/__tests__/Validation.test.tsx
@@ -42,7 +42,7 @@ describe('DatePicker validation', () => {
     expect(onErrorMock).toBeCalledWith(expectedError, expect.anything());
   });
 
-  test('It should properly annulate the error', () => {
+  it('It should properly annulate the error', () => {
     if (process.env.UTILS === 'luxon') {
       return;
     }

--- a/lib/src/__tests__/unit/text-field-helper.test.ts
+++ b/lib/src/__tests__/unit/text-field-helper.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../../_helpers/text-field-helper';
 
 describe('test-field-helper', () => {
-  test('maskedDateFormatter for date', () => {
+  it('maskedDateFormatter for date', () => {
     const formatterFn = maskedDateFormatter('__/__/____', /[\d]/gi);
 
     expect(formatterFn('21')).toBe('21/');
@@ -21,7 +21,7 @@ describe('test-field-helper', () => {
     expect(formatterFn('2f')).toBe('2');
   });
 
-  test('maskedDateFormatter for time', () => {
+  it('maskedDateFormatter for time', () => {
     const formatterFn = maskedDateFormatter('__:__ _M', /[\dap]/gi);
 
     expect(formatterFn('10')).toBe('10:');
@@ -29,7 +29,7 @@ describe('test-field-helper', () => {
     expect(formatterFn('10:00 A')).toBe('10:00 AM');
   });
 
-  test('pick12hOr24hFormat', () => {
+  it('pick12hOr24hFormat', () => {
     expect(
       pick12hOr24hFormat(undefined, true, { localized: 'T', '12h': 'hh:mm a', '24h': 'HH:mm' })
     ).toBe('hh:mm a');

--- a/lib/src/_helpers/date-utils.ts
+++ b/lib/src/_helpers/date-utils.ts
@@ -159,7 +159,9 @@ export interface DateValidationProps {
    * @default Date(2100-01-01)
    */
   maxDate?: MaterialUiPickersDate;
-  /** Disable specific date @DateIOType */
+  /**
+   * Disable specific date @DateIOType
+   */
   shouldDisableDate?: (day: MaterialUiPickersDate) => boolean;
   /**
    * Disable past dates

--- a/lib/src/_helpers/date-utils.ts
+++ b/lib/src/_helpers/date-utils.ts
@@ -150,26 +150,26 @@ export const isEndOfRange = (
 
 export interface DateValidationProps {
   /**
-   * Min selectable date
+   * Min selectable date.
    * @default Date(1900-01-01)
    */
   minDate?: MaterialUiPickersDate;
   /**
-   * Max selectable date
+   * Max selectable date.
    * @default Date(2100-01-01)
    */
   maxDate?: MaterialUiPickersDate;
   /**
-   * Disable specific date @DateIOType
+   * Disable specific date @DateIOType.
    */
   shouldDisableDate?: (day: MaterialUiPickersDate) => boolean;
   /**
-   * Disable past dates
+   * Disable past dates.
    * @default false
    */
   disablePast?: boolean;
   /**
-   * Disable future dates
+   * Disable future dates.
    * @default false
    */
   disableFuture?: boolean;

--- a/lib/src/_helpers/time-utils.ts
+++ b/lib/src/_helpers/time-utils.ts
@@ -109,13 +109,23 @@ export const createIsAfterIgnoreDatePart = (
 };
 
 export interface TimeValidationProps {
-  /** Min time acceptable time. For input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified. */
+  /**
+   * Min time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified.
+   */
   minTime?: MaterialUiPickersDate;
-  /** Max time acceptable time. For input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified. */
+  /**
+   * Max time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableTimeValidationIgnoreDatePart` not specified.
+   */
   maxTime?: MaterialUiPickersDate;
-  /** Dynamically check if time is disabled or not. If returns `false` appropriate time point will ot be acceptable. */
+  /**
+   * Dynamically check if time is disabled or not.
+   * If returns `false` appropriate time point will ot be acceptable.
+   */
   shouldDisableTime?: (timeValue: number, clockType: 'hours' | 'minutes' | 'seconds') => boolean;
-  /** Do not ignore date part when validating min/max time
+  /**
+   * Do not ignore date part when validating min/max time
    * @default false
    */
   disableTimeValidationIgnoreDatePart?: boolean;

--- a/lib/src/_helpers/utils.ts
+++ b/lib/src/_helpers/utils.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-/** Use it instead of .includes method for IE support */
+/* Use it instead of .includes method for IE support */
 export function arrayIncludes<T>(array: T[] | readonly T[], itemOrItems: T | T[]) {
   if (Array.isArray(itemOrItems)) {
     return itemOrItems.every(item => array.indexOf(item) !== -1);
@@ -26,7 +26,7 @@ export const onSpaceOrEnter = (
   }
 };
 
-/** Quick untyped helper to improve function composition readability */
+/* Quick untyped helper to improve function composition readability */
 export const pipe = (...fns: ((...args: any[]) => any)[]) =>
   fns.reduceRight(
     (prevFn, nextFn) => (...args) => nextFn(prevFn(...args)),
@@ -38,14 +38,14 @@ export const executeInTheNextEventLoopTick = (fn: () => void) => {
 };
 
 export function createDelegatedEventHandler<TEvent>(
-  fn: (e: TEvent) => void,
-  onEvent?: (e: TEvent) => void
+  fn: (event: TEvent) => void,
+  onEvent?: (event: TEvent) => void
 ) {
-  return (e: TEvent) => {
-    fn(e);
+  return (event: TEvent) => {
+    fn(event);
 
     if (onEvent) {
-      onEvent(e);
+      onEvent(event);
     }
   };
 }
@@ -62,5 +62,3 @@ export function mergeRefs<T>(refs: (React.Ref<T | null> | undefined)[]) {
     });
   };
 }
-
-export const doNothing = () => {};

--- a/lib/src/_shared/ArrowSwitcher.tsx
+++ b/lib/src/_shared/ArrowSwitcher.tsx
@@ -36,10 +36,10 @@ export interface ExportedArrowSwitcherProps {
 }
 
 interface ArrowSwitcherProps extends ExportedArrowSwitcherProps, React.HTMLProps<HTMLDivElement> {
-  isLeftHidden?: boolean;
-  isRightHidden?: boolean;
   isLeftDisabled: boolean;
+  isLeftHidden?: boolean;
   isRightDisabled: boolean;
+  isRightHidden?: boolean;
   onLeftClick: () => void;
   onRightClick: () => void;
   text?: string;
@@ -63,17 +63,17 @@ export const useStyles = makeStyles(
 
 const PureArrowSwitcher: React.FC<ArrowSwitcherProps> = ({
   className,
+  isLeftDisabled,
+  isLeftHidden,
+  isRightDisabled,
+  isRightHidden,
   leftArrowButtonProps,
   leftArrowButtonText,
-  rightArrowButtonProps,
-  rightArrowButtonText,
-  isLeftHidden,
-  isRightHidden,
-  isLeftDisabled,
-  isRightDisabled,
+  leftArrowIcon = <ArrowLeftIcon />,
   onLeftClick,
   onRightClick,
-  leftArrowIcon = <ArrowLeftIcon />,
+  rightArrowButtonProps,
+  rightArrowButtonText,
   rightArrowIcon = <ArrowRightIcon />,
   text,
   ...other

--- a/lib/src/_shared/ArrowSwitcher.tsx
+++ b/lib/src/_shared/ArrowSwitcher.tsx
@@ -7,13 +7,21 @@ import { ArrowRightIcon } from './icons/ArrowRightIcon';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 
 export interface ExportedArrowSwitcherProps {
-  /** Left arrow icon */
+  /**
+   * Left arrow icon
+   */
   leftArrowIcon?: React.ReactNode;
-  /** Right arrow icon */
+  /**
+   * Right arrow icon
+   */
   rightArrowIcon?: React.ReactNode;
-  /** Left arrow icon aria-label text */
+  /**
+   * Left arrow icon aria-label text
+   */
   leftArrowButtonText?: string;
-  /** Right arrow icon aria-label text */
+  /**
+   * Right arrow icon aria-label text
+   */
   rightArrowButtonText?: string;
   /**
    * Props to pass to left arrow button

--- a/lib/src/_shared/KeyboardDateInput.tsx
+++ b/lib/src/_shared/KeyboardDateInput.tsx
@@ -9,16 +9,16 @@ import { DateInputProps, DateInputRefs } from './PureDateInput';
 import { getTextFieldAriaText } from '../_helpers/text-field-helper';
 
 export const KeyboardDateInput: React.FC<DateInputProps & DateInputRefs> = ({
-  renderInput,
-  openPicker: onOpen,
-  InputProps,
-  InputAdornmentProps,
-  openPickerIcon = <CalendarIcon />,
-  OpenPickerButtonProps,
-  disableOpenPicker: hideOpenPickerButton,
-  getOpenDialogAriaText = getTextFieldAriaText,
   containerRef,
+  disableOpenPicker: hideOpenPickerButton,
   forwardedRef,
+  getOpenDialogAriaText = getTextFieldAriaText,
+  InputAdornmentProps,
+  InputProps,
+  openPicker: onOpen,
+  OpenPickerButtonProps,
+  openPickerIcon = <CalendarIcon />,
+  renderInput,
   ...other
 }) => {
   const utils = useUtils();
@@ -52,11 +52,11 @@ export const KeyboardDateInput: React.FC<DateInputProps & DateInputRefs> = ({
 };
 
 KeyboardDateInput.propTypes = {
-  renderInput: PropTypes.func.isRequired,
-  mask: PropTypes.string,
-  rifmFormatter: PropTypes.func,
-  openPickerIcon: PropTypes.node,
-  OpenPickerButtonProps: PropTypes.object,
   acceptRegex: PropTypes.instanceOf(RegExp),
   getOpenDialogAriaText: PropTypes.func,
+  mask: PropTypes.string,
+  OpenPickerButtonProps: PropTypes.object,
+  openPickerIcon: PropTypes.node,
+  renderInput: PropTypes.func.isRequired,
+  rifmFormatter: PropTypes.func,
 };

--- a/lib/src/_shared/PickerModalDialog.tsx
+++ b/lib/src/_shared/PickerModalDialog.tsx
@@ -44,8 +44,8 @@ export interface ExportedPickerModalProps {
 
 export interface PickerModalDialogProps extends ExportedPickerModalProps, DialogProps {
   onAccept: () => void;
-  onDismiss: () => void;
   onClear: () => void;
+  onDismiss: () => void;
   onSetToday: () => void;
 }
 
@@ -84,20 +84,20 @@ export const useStyles = makeStyles(
 );
 
 export const PickerModalDialog: React.FC<PickerModalDialogProps> = ({
-  children,
-  onAccept,
-  onDismiss,
-  onClear,
-  onSetToday,
-  okText = 'OK',
   cancelText = 'Cancel',
-  clearText = 'Clear',
-  todayText = 'Today',
-  clearable = false,
-  showTodayButton = false,
-  showTabs,
-  wider,
+  children,
   classes: MuiDialogClasses,
+  clearable = false,
+  clearText = 'Clear',
+  okText = 'OK',
+  onAccept,
+  onClear,
+  onDismiss,
+  onSetToday,
+  showTabs,
+  showTodayButton = false,
+  todayText = 'Today',
+  wider,
   ...other
 }) => {
   const classes = useStyles();

--- a/lib/src/_shared/PickerToolbar.tsx
+++ b/lib/src/_shared/PickerToolbar.tsx
@@ -67,7 +67,7 @@ const PickerToolbar: React.SFC<PickerToolbarProps> = ({
   isLandscape,
   toolbarTitle,
   landscapeDirection = 'column',
-  className = null,
+  className,
   penIconClassName,
   toggleMobileKeyboardView,
   isMobileKeyboardViewOpen,

--- a/lib/src/_shared/PickerToolbar.tsx
+++ b/lib/src/_shared/PickerToolbar.tsx
@@ -64,14 +64,14 @@ function defaultGetKeyboardInputSwitchingButtonText(isKeyboardInputOpen: boolean
 
 const PickerToolbar: React.SFC<PickerToolbarProps> = ({
   children,
-  isLandscape,
-  toolbarTitle,
-  landscapeDirection = 'column',
   className,
+  getMobileKeyboardInputViewButtonText = defaultGetKeyboardInputSwitchingButtonText,
+  isLandscape,
+  isMobileKeyboardViewOpen,
+  landscapeDirection = 'column',
   penIconClassName,
   toggleMobileKeyboardView,
-  isMobileKeyboardViewOpen,
-  getMobileKeyboardInputViewButtonText = defaultGetKeyboardInputSwitchingButtonText,
+  toolbarTitle,
   ...other
 }) => {
   const classes = useStyles();

--- a/lib/src/_shared/PureDateInput.tsx
+++ b/lib/src/_shared/PureDateInput.tsx
@@ -36,36 +36,40 @@ export interface DateInputProps<TInputValue = ParsableDate, TDateValue = Materia
    * ````
    */
   renderInput: (props: MuiTextFieldProps) => React.ReactElement;
-  /** Icon displaying for open picker button */
+  /**
+   * Icon displaying for open picker button.
+   * */
   openPickerIcon?: React.ReactNode;
   /**
    * Custom mask. Can be used to override generate from format. (e.g. __/__/____ __:__ or __/__/____ __:__ _M)
    */
   mask?: string;
   /**
-   *Regular expression to detect "accepted" symbols
+   *Regular expression to detect "accepted" symbols.
    * @default /\dap/gi
    */
   acceptRegex?: RegExp;
   /**
-   * Props to pass to keyboard input adornment
+   * Props to pass to keyboard input adornment.
    * @type {Partial<InputAdornmentProps>}
    */
   InputAdornmentProps?: Partial<InputAdornmentProps>;
   /**
-   * Props to pass to keyboard adornment button
+   * Props to pass to keyboard adornment button.
    * @type {Partial<IconButtonProps>}
    */
   OpenPickerButtonProps?: Partial<IconButtonProps>;
-  /** Custom formatter to be passed into Rifm component */
+  /**
+   * Custom formatter to be passed into Rifm component.
+   */
   rifmFormatter?: (str: string) => string;
   /**
-   * Do not render open picker button (renders only text field with validation)
+   * Do not render open picker button (renders only text field with validation).
    * @default false
    */
   disableOpenPicker?: boolean;
   /**
-   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format
+   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.
    * @default false
    */
   disableMaskedInput?: boolean;

--- a/lib/src/_shared/PureDateInput.tsx
+++ b/lib/src/_shared/PureDateInput.tsx
@@ -100,18 +100,18 @@ export interface DateInputRefs {
 }
 
 export const PureDateInput: React.FC<DateInputProps & DateInputRefs> = ({
-  inputFormat,
-  rawValue,
-  validationError,
-  InputProps,
-  openPicker: onOpen,
-  renderInput,
-  forwardedRef,
   containerRef,
-  getOpenDialogAriaText = getTextFieldAriaText,
   disabled,
+  forwardedRef,
+  getOpenDialogAriaText = getTextFieldAriaText,
+  inputFormat,
+  InputProps,
   label,
+  openPicker: onOpen,
+  rawValue,
+  renderInput,
   TextFieldProps = {},
+  validationError,
 }) => {
   const utils = useUtils();
   const PureDateInputProps = React.useMemo(

--- a/lib/src/_shared/ToolbarButton.tsx
+++ b/lib/src/_shared/ToolbarButton.tsx
@@ -30,7 +30,7 @@ export const ToolbarButton: React.FunctionComponent<ToolbarButtonProps> = ({
   className,
   selected,
   typographyClassName,
-  value: label,
+  value,
   variant,
   ...other
 }) => {
@@ -47,7 +47,7 @@ export const ToolbarButton: React.FunctionComponent<ToolbarButtonProps> = ({
         align={align}
         className={typographyClassName}
         variant={variant}
-        value={label}
+        value={value}
         selected={selected}
       />
     </Button>

--- a/lib/src/_shared/ToolbarButton.tsx
+++ b/lib/src/_shared/ToolbarButton.tsx
@@ -7,11 +7,11 @@ import { makeStyles } from '@material-ui/core/styles';
 import { TypographyProps } from '@material-ui/core/Typography';
 
 export interface ToolbarButtonProps extends ExtendMui<ButtonProps, 'value' | 'variant'> {
-  variant: TypographyProps['variant'];
-  selected: boolean;
-  value: React.ReactNode;
   align?: TypographyProps['align'];
+  selected: boolean;
   typographyClassName?: string;
+  value: React.ReactNode;
+  variant: TypographyProps['variant'];
 }
 
 export const useStyles = makeStyles(

--- a/lib/src/_shared/ToolbarButton.tsx
+++ b/lib/src/_shared/ToolbarButton.tsx
@@ -26,12 +26,12 @@ export const useStyles = makeStyles(
 );
 
 export const ToolbarButton: React.FunctionComponent<ToolbarButtonProps> = ({
-  className = null,
-  value: label,
-  selected,
-  variant,
   align,
+  className,
+  selected,
   typographyClassName,
+  value: label,
+  variant,
   ...other
 }) => {
   const classes = useStyles();

--- a/lib/src/_shared/ToolbarText.tsx
+++ b/lib/src/_shared/ToolbarText.tsx
@@ -30,9 +30,9 @@ export const useStyles = makeStyles(
 );
 
 const ToolbarText: React.FC<ToolbarTextProps> = ({
+  className,
   selected,
   value: label,
-  className = null,
   ...other
 }) => {
   const classes = useStyles();

--- a/lib/src/typings/BasePicker.tsx
+++ b/lib/src/typings/BasePicker.tsx
@@ -6,49 +6,75 @@ export interface BasePickerProps<
   TInputValue = ParsableDate,
   TDateValue = MaterialUiPickersDate | null
 > {
-  /** Picker value */
+  /**
+   * Picker value.
+   */
   value: TInputValue;
-  /** onChange callback @DateIOType */
+  /**
+   * onChange callback @DateIOType.
+   */
   onChange: (date: TDateValue, keyboardInputValue?: string) => void;
   /**
-   * Auto accept date on selection
+   * Auto accept date on selection.
    * @default false
    */
   autoOk?: boolean;
-  /** Format string */
+  /**
+   * Format string.
+   */
   inputFormat?: string;
-  /** Disable picker and text field */
+  /**
+   * Disable picker and text field.
+   */
   disabled?: boolean;
-  /** Make picker read only */
+  /**
+   * Make picker read only.
+   */
   readOnly?: boolean;
-  /** Callback fired when date is accepted @DateIOType */
+  /**
+   * Callback fired when date is accepted @DateIOType.
+   */
   onAccept?: (date: TDateValue) => void;
-  /** On open callback */
+  /**
+   * On open callback.
+   */
   onOpen?: () => void;
-  /** On close callback */
+  /**
+   * On close callback.
+   */
   onClose?: () => void;
-  /** Controlled picker open state */
+  /**
+   * Controlled picker open state.
+   */
   open?: boolean;
   /**
-   * Show toolbar even in desktop mode
+   * Show toolbar even in desktop mode.
    */
   showToolbar?: boolean;
-  /** Force rendering in particular orientation */
+  /**
+   * Force rendering in particular orientation.
+   */
   orientation?: 'portrait' | 'landscape';
-  /** Component that will replace default toolbar renderer */
+  /**
+   * Component that will replace default toolbar renderer.
+   */
   ToolbarComponent?: React.ComponentType<ToolbarComponentProps>;
   /**
-   * Mobile picker title, displaying in the toolbar
+   * Mobile picker title, displaying in the toolbar.
    * @default "SELECT DATE"
    */
   toolbarTitle?: React.ReactNode;
   /**
-   * Mobile picker date value placeholder, displaying if `value` === `null`
+   * Mobile picker date value placeholder, displaying if `value` === `null`.
    * @default "–"
    */
   toolbarPlaceholder?: React.ReactNode;
-  /** Date format, that is displaying in toolbar */
+  /**
+   * Date format, that is displaying in toolbar.
+   */
   toolbarFormat?: string;
-  /** className applied to the root component */
+  /**
+   * className applied to the root component.
+   */
   className?: string;
 }

--- a/lib/src/views/Calendar/Calendar.tsx
+++ b/lib/src/views/Calendar/Calendar.tsx
@@ -12,20 +12,26 @@ import { SlideTransition, SlideDirection, SlideTransitionProps } from './SlideTr
 
 export interface ExportedCalendarProps
   extends Pick<DayProps, 'disableHighlightToday' | 'showDaysOutsideCurrentMonth'> {
-  /** Calendar onChange */
+  /**
+   * Calendar onChange.
+   */
   onChange: PickerOnChangeFn;
-  /** Custom renderer for day. Check [DayComponentProps api](https://material-ui-pickers.dev/api/Day) @DateIOType */
+  /**
+   * Custom renderer for day. Check [DayComponentProps api](https://material-ui-pickers.dev/api/Day) @DateIOType.
+   */
   renderDay?: (
     day: MaterialUiPickersDate,
     selectedDates: MaterialUiPickersDate[],
     DayComponentProps: DayProps
   ) => JSX.Element;
   /**
-   * Enables keyboard listener for moving between days in calendar
+   * Enables keyboard listener for moving between days in calendar.
    * @default currentWrapper !== 'static'
    */
   allowKeyboardControl?: boolean;
-  /** Custom loading indicator  */
+  /**
+   * Custom loading indicator.
+   */
   loadingIndicator?: JSX.Element;
 }
 

--- a/lib/src/views/Calendar/CalendarHeader.tsx
+++ b/lib/src/views/Calendar/CalendarHeader.tsx
@@ -24,7 +24,9 @@ export interface CalendarHeaderProps
   view: DatePickerView;
   views: DatePickerView[];
   currentMonth: MaterialUiPickersDate;
-  /** Get aria-label text for switching between views button */
+  /**
+   * Get aria-label text for switching between views button.
+   */
   getViewSwitchingButtonText?: (currentView: DatePickerView) => string;
   reduceAnimations: boolean;
   changeView: (view: DatePickerView) => void;

--- a/lib/src/views/Calendar/CalendarView.tsx
+++ b/lib/src/views/Calendar/CalendarView.tsx
@@ -38,9 +38,13 @@ export interface CalendarViewProps
   views: DatePickerView[];
   changeView: (view: DatePickerView) => void;
   onChange: PickerOnChangeFn;
-  /** Disable heavy animations @default /(android)/i.test(window.navigator.userAgent) */
+  /**
+   * Disable heavy animations @default /(android)/i.test(window.navigator.userAgent).
+   */
   reduceAnimations?: boolean;
-  /** Callback firing on month change. Return promise to render spinner till it will not be resolved @DateIOType */
+  /**
+   * Callback firing on month change. Return promise to render spinner till it will not be resolved @DateIOType.
+   */
   onMonthChange?: (date: MaterialUiPickersDate) => void | Promise<void>;
 }
 

--- a/lib/src/views/Calendar/CalendarView.tsx
+++ b/lib/src/views/Calendar/CalendarView.tsx
@@ -39,7 +39,8 @@ export interface CalendarViewProps
   changeView: (view: DatePickerView) => void;
   onChange: PickerOnChangeFn;
   /**
-   * Disable heavy animations @default /(android)/i.test(window.navigator.userAgent).
+   * Disable heavy animations.
+   * @default /(android)/i.test(window.navigator.userAgent).
    */
   reduceAnimations?: boolean;
   /**

--- a/lib/src/views/Calendar/Day.tsx
+++ b/lib/src/views/Calendar/Day.tsx
@@ -71,32 +71,53 @@ export const useStyles = makeStyles(
 );
 
 export interface DayProps extends ExtendMui<ButtonBaseProps> {
-  /** The date to show */
+  /**
+   * The date to show.
+   */
   day: MaterialUiPickersDate;
-  /** Is focused by keyboard navigation */
+  /**
+   * Is focused by keyboard navigation.
+   */
   focused?: boolean;
-  /** Can be focused by tabbing in */
+  /**
+   * Can be focused by tabbing in.
+   */
   focusable?: boolean;
-  /** Is day in current month */
+  /**
+   * Is day in current month.
+   */
   inCurrentMonth: boolean;
-  /** Is switching month animation going on right now */
+  /**
+   * Is switching month animation going on right now.
+   */
   isAnimating?: boolean;
-  /** Is today? */
+  /**
+   * Is today?
+   */
   today?: boolean;
-  /** Disabled? */
+  /**
+   * Disabled?.
+   */
   disabled?: boolean;
-  /** Selected? */
+  /**
+   * Selected?
+   */
   selected?: boolean;
-  /** Is keyboard control and focus management enabled */
+  /**
+   * Is keyboard control and focus management enabled.
+   */
   allowKeyboardControl?: boolean;
-  /** Disable margin between days, useful for displaying range of days */
+  /**
+   * Disable margin between days, useful for displaying range of days.
+   */
   disableMargin?: boolean;
   /**
-   * Display disabled dates outside the current month
+   * Display disabled dates outside the current month.
    * @default false
    */
   showDaysOutsideCurrentMonth?: boolean;
-  /** Disable highlighting today date with a circle
+  /**
+   * Disable highlighting today date with a circle.
    * @default false
    */
   disableHighlightToday?: boolean;

--- a/lib/src/views/Calendar/Day.tsx
+++ b/lib/src/views/Calendar/Day.tsx
@@ -34,7 +34,7 @@ export const useStyles = makeStyles(
       },
     },
     dayWithMargin: {
-      margin: `0px ${DAY_MARGIN}px`,
+      margin: `0 ${DAY_MARGIN}px`,
     },
     dayOutsideMonth: {
       color: theme.palette.text.hint,

--- a/lib/src/views/Calendar/FadeTransitionGroup.tsx
+++ b/lib/src/views/Calendar/FadeTransitionGroup.tsx
@@ -44,9 +44,9 @@ export const useStyles = makeStyles(
 
 export const FadeTransitionGroup: React.FC<FadeTransitionProps> = ({
   children,
-  transKey,
+  className,
   reduceAnimations,
-  className = null,
+  transKey,
 }) => {
   const classes = useStyles();
   if (reduceAnimations) {

--- a/lib/src/views/Calendar/YearSelection.tsx
+++ b/lib/src/views/Calendar/YearSelection.tsx
@@ -7,9 +7,14 @@ import { WrapperVariantContext } from '../../wrappers/WrapperVariantContext';
 import { useGlobalKeyDown, keycode as keys } from '../../_shared/hooks/useKeyDown';
 
 export interface ExportedYearSelectionProps {
-  /** Callback firing on year change @DateIOType */
+  /**
+   * Callback firing on year change @DateIOType.
+   */
   onYearChange?: (date: MaterialUiPickersDate) => void;
-  /** Disable specific years dynamically. Works like `shouldDisableDate` but for year selection view. @DateIOType */
+  /**
+   * Disable specific years dynamically.
+   * Works like `shouldDisableDate` but for year selection view. @DateIOType.
+   */
   shouldDisableYear?: (day: MaterialUiPickersDate) => boolean;
 }
 

--- a/lib/src/views/Clock/ClockView.tsx
+++ b/lib/src/views/Clock/ClockView.tsx
@@ -39,19 +39,33 @@ export interface ExportedClockViewProps extends TimeValidationProps {
 }
 
 export interface ClockViewProps extends ExportedClockViewProps, ExportedArrowSwitcherProps {
-  /** Selected date @DateIOType */
+  /**
+   * Selected date @DateIOType.
+   */
   date: MaterialUiPickersDate;
-  /** Clock type */
+  /**
+   * Clock type.
+   */
   type: 'hours' | 'minutes' | 'seconds';
-  /** On change date without moving between views @DateIOType */
+  /**
+   * On change date without moving between views @DateIOType.
+   */
   onDateChange: PickerOnChangeFn;
-  /** On change callback @DateIOType */
+  /**
+   * On change callback @DateIOType.
+   */
   onChange: PickerOnChangeFn;
-  /** Get clock number aria-text for hours */
+  /**
+   * Get clock number aria-text for hours.
+   */
   getHoursClockNumberText?: (hoursText: string) => string;
-  /** Get clock number aria-text for minutes */
+  /**
+   * Get clock number aria-text for minutes.
+   */
   getMinutesClockNumberText?: (minutesText: string) => string;
-  /** Get clock number aria-text for seconds */
+  /**
+   * Get clock number aria-text for seconds.
+   */
   getSecondsClockNumberText?: (secondsText: string) => string;
   openNextView: () => void;
   openPreviousView: () => void;

--- a/lib/src/views/Clock/ClockView.tsx
+++ b/lib/src/views/Clock/ClockView.tsx
@@ -284,10 +284,10 @@ export const ClockView: React.FC<ClockViewProps> = ({
 };
 
 ClockView.propTypes = {
-  date: PropTypes.object,
-  onChange: PropTypes.func.isRequired,
   ampm: PropTypes.bool,
+  date: PropTypes.object,
   minutesStep: PropTypes.number,
+  onChange: PropTypes.func.isRequired,
   type: PropTypes.oneOf(['minutes', 'hours', 'seconds']).isRequired,
 } as any;
 

--- a/lib/src/wrappers/DesktopPopperWrapper.tsx
+++ b/lib/src/wrappers/DesktopPopperWrapper.tsx
@@ -18,9 +18,13 @@ import { useGlobalKeyDown, keycode } from '../_shared/hooks/useKeyDown';
 import { TransitionProps } from '@material-ui/core/transitions/transition';
 
 export interface InnerDesktopPopperWrapperProps {
-  /** Popper props passed to material-ui [Popper](https://material-ui.com/api/popper/#popper-api) */
+  /**
+   * Popper props passed to material-ui [Popper](https://material-ui.com/api/popper/#popper-api).
+   */
   PopperProps?: Partial<PopperProps>;
-  /** Custom component for [transition](https://material-ui.com/components/transitions/#transitioncomponent-prop)  */
+  /**
+   * Custom component for [transition](https://material-ui.com/components/transitions/#transitioncomponent-prop).
+   */
   TransitionComponent?: React.ComponentType<TransitionProps>;
 }
 

--- a/lib/src/wrappers/DesktopWrapper.tsx
+++ b/lib/src/wrappers/DesktopWrapper.tsx
@@ -11,7 +11,9 @@ import { KeyboardDateInput } from '../_shared/KeyboardDateInput';
 import { InnerDesktopPopperWrapperProps } from './DesktopPopperWrapper';
 
 export interface InnerDesktopWrapperProps {
-  /** Popover props passed to material-ui Popover */
+  /**
+   * Popover props passed to material-ui Popover.
+   */
   PopoverProps?: Partial<PopoverProps>;
 }
 

--- a/lib/src/wrappers/ResponsiveWrapper.tsx
+++ b/lib/src/wrappers/ResponsiveWrapper.tsx
@@ -9,7 +9,9 @@ export interface ResponsiveWrapperProps
   extends DesktopWrapperProps,
     DesktopPopperWrapperProps,
     MobileWrapperProps {
-  /** Css media query when `Mobile` mode will be changed to `Desktop`
+  /**
+   * CSS media query when `Mobile` mode will be changed to `Desktop`.
+   *
    * @default "@media (pointer: fine)"
    * @example "@media (min-width: 720px)" or theme.breakpoints.up("sm")
    */

--- a/lib/src/wrappers/makeWrapperComponent.tsx
+++ b/lib/src/wrappers/makeWrapperComponent.tsx
@@ -16,7 +16,7 @@ interface WithWrapperProps<TInputProps = DateInputProps> {
   wrapperProps: Omit<WrapperProps, 'DateInputProps'>;
 }
 
-/** Creates a component that rendering modal/popover/nothing and spreading props down to text field */
+/* Creates a component that rendering modal/popover/nothing and spreading props down to text field */
 export function makeWrapperComponent<
   TInputProps extends DateInputPropsLike<TInputValue, TDateValue>,
   TInputValue,

--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
-  "name": "@material-ui/pickers",
-  "version": "2.0.0",
+  "version": "4.0.0",
+  "private": true,
   "description": "Material-ui pickers root package",
   "main": "index.js",
   "directories": {
     "doc": "docs",
     "lib": "lib"
   },
-  "private": true,
   "workspaces": [
     "lib",
     "docs"


### PR DESCRIPTION
- remove the null default value on the `className` prop, it's not required.
- use `it` over `test` as more frequently used in the codebase (they are aliases).
- remove the name of the root package to avoid confusion, it can't be published.
- sort ASC a couple of props.
- update the version on the root package to v4, the current working version.
- avoid alias 2212ccd: save a bit of bundle size and reduce cognitive overhead.
- normalize types comment 89ddefa: use the same code comment syntax as in the main repository
- sort prop asc d6fcaf6: make is easier to navigate
- remove empty function d60c239
- use shorthand notation 5d90550
- fix wrong @default API usage b21de7d