### PR TITLE
[docs] make DateTimePickerValidation example work out of the box

### DIFF
--- a/docs/pages/demo/datetime-picker/DateTimeValidation.example.jsx
+++ b/docs/pages/demo/datetime-picker/DateTimeValidation.example.jsx
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
 import { TextField } from '@material-ui/core';
 import { DateTimePicker } from '@material-ui/pickers';
+import { LocalizationProvider } from '@material-ui/pickers';
+import DateFnsUtils from '@material-ui/pickers/adapter/date-fns';  // choose your date lib
 
 function DateTimePickerValidation() {
   const [selectedDate, handleDateChange] = useState(new Date());
 
   return (
-    <>
+    <LocalizationProvider dateAdapter={DateFnsUtils}>
       <DateTimePicker
         renderInput={props => <TextField {...props} />}
         label="Ignore date and time"
@@ -24,7 +26,7 @@ function DateTimePickerValidation() {
         minTime={new Date(0, 0, 0, 8)}
         maxTime={new Date(0, 0, 0, 18, 45)}
       />
-    </>
+    </LocalizationProvider>
   );
 }
 


### PR DESCRIPTION
That example generates warnings [in the CSB](https://codesandbox.io/s/material-keyboarddatetimepicker-with-rhf-jqv1c?file=/index.tsx) console though (#1776).

> The mask "__/__/____ __:__ _M" you passed is not valid for the format used P p. Falling down to uncontrolled not-masked input. 

![image](https://user-images.githubusercontent.com/33569/82781911-f2988000-9e0f-11ea-8692-44bd2b04644a.png)
