### PR TITLE
Move InputProps to last for override default input adornment

### DIFF
--- a/lib/src/_shared/KeyboardDateInput.tsx
+++ b/lib/src/_shared/KeyboardDateInput.tsx
@@ -104,7 +104,6 @@ export const KeyboardDateInput: React.FunctionComponent<KeyboardDateInputProps> 
           onChange={onChange}
           variant={inputVariant as any}
           InputProps={{
-            ...InputProps,
             [`${position}Adornment`]: (
               <InputAdornment position={position} {...InputAdornmentProps}>
                 <IconButton disabled={disabled} {...KeyboardButtonProps} onClick={onOpen}>
@@ -112,6 +111,7 @@ export const KeyboardDateInput: React.FunctionComponent<KeyboardDateInputProps> 
                 </IconButton>
               </InputAdornment>
             ),
+            ...InputProps,
           }}
         />
       )}


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

## Description

At now, InputProps.endAdornment is not working in KeyboardDatePicker component. Even though open picker button is desired behavior of KeyboardDateInput component, it needs to be customized.
