### PR TITLE
[docs] Prepare Material-UI X

### DIFF
--- a/docs/pages/demo/daterangepicker/index.mdx
+++ b/docs/pages/demo/daterangepicker/index.mdx
@@ -18,7 +18,7 @@ import * as CustomRangeInputs from './CustomRangeInputs.example';
 > ⚠️⚠️ The date range picker is unstable, it's **not suitable** for usage in production. ⚠️⚠️
 
 > The date range picker will be made available in the coming months for production use as part of a paid extension to the community edition (MIT license) of Material-UI.
-> This paid extension will include advanced components (rich data grid, date range picker, tree view drag & drop, etc.). Pricing plans will start at \$129/developer for early access.
+> This paid extension will include advanced components (rich data grid, date range picker, tree view drag & drop, etc.). Pricing for early access will start with an affordable plan.
 
 The [date range pickers](https://material.io/components/pickers/) let users select a range of dates. 
 

--- a/docs/pages/demo/daterangepicker/index.mdx
+++ b/docs/pages/demo/daterangepicker/index.mdx
@@ -13,9 +13,14 @@ import * as CustomRangeInputs from './CustomRangeInputs.example';
 
 <PageMeta component="DateRangePicker" />
 
-## Date picker
+## Date range picker
 
-[Date pickers](https://material.io/components/pickers/) let users select a date, or a range of dates. They should be suitable for the context in which they appear.
+> ⚠️⚠️ The date range picker is unstable, it's **not suitable** for usage in production. ⚠️⚠️
+
+> The date range picker will be made available in the coming month for production usage as part of a paid extension of the community edition (MIT license) of Material-UI.
+> This paid extension will include advanced components (rich data grid, date range picker, tree view drag & drop, etc.). Pricing plans will start at \$129/developer for early access.
+
+The [date range pickers](https://material.io/components/pickers/) let users select a range of dates. They should be suitable for the context in which they appear.
 
 <Ad />
 

--- a/docs/pages/demo/daterangepicker/index.mdx
+++ b/docs/pages/demo/daterangepicker/index.mdx
@@ -17,7 +17,7 @@ import * as CustomRangeInputs from './CustomRangeInputs.example';
 
 > ⚠️⚠️ The date range picker is unstable, it's **not suitable** for usage in production. ⚠️⚠️
 
-> The date range picker will be made available in the coming month for production usage as part of a paid extension of the community edition (MIT license) of Material-UI.
+> The date range picker will be made available in the coming months for production use as part of a paid extension to the community edition (MIT license) of Material-UI.
 > This paid extension will include advanced components (rich data grid, date range picker, tree view drag & drop, etc.). Pricing plans will start at \$129/developer for early access.
 
 The [date range pickers](https://material.io/components/pickers/) let users select a range of dates. They should be suitable for the context in which they appear.

--- a/docs/pages/demo/daterangepicker/index.mdx
+++ b/docs/pages/demo/daterangepicker/index.mdx
@@ -20,7 +20,7 @@ import * as CustomRangeInputs from './CustomRangeInputs.example';
 > The date range picker will be made available in the coming months for production use as part of a paid extension to the community edition (MIT license) of Material-UI.
 > This paid extension will include advanced components (rich data grid, date range picker, tree view drag & drop, etc.). Pricing plans will start at \$129/developer for early access.
 
-The [date range pickers](https://material.io/components/pickers/) let users select a range of dates. They should be suitable for the context in which they appear.
+The [date range pickers](https://material.io/components/pickers/) let users select a range of dates. 
 
 <Ad />
 


### PR DESCRIPTION
Preview:

<img width="1043" alt="Capture d’écran 2020-06-14 à 12 23 5" src="https://user-images.githubusercontent.com/3165635/84590834-23ca0600-ae3a-11ea-9d89-e02c5274a073.png">

@dmtrKovalenko Regarding the ad, it's not right, do you want to contact CodeFund to block Kendo and Syncfusion? Alternatively, it might be simpler to switch the property to Material-UI, a bit ahead of time, we already have this blacklist in place.