### PR TITLE
[docs] Fix DatePicker of 'Customization' section

### DIFF
--- a/docs/pages/demo/datepicker/CustomDay.example.jsx
+++ b/docs/pages/demo/datepicker/CustomDay.example.jsx
@@ -35,7 +35,7 @@ function WeekPicker(props) {
 
   const renderWeekPickerDay = (date, selectedDates, DayComponentProps) => {
     let dateClone = makeJSDateObject(date);
-    let selectedDateClone = makeJSDateObject(selectedDates[0]);
+    let selectedDateClone = makeJSDateObject(selectedDate);
 
     const start = startOfWeek(selectedDateClone);
     const end = endOfWeek(selectedDateClone);

--- a/docs/pages/demo/datepicker/CustomDay.example.jsx
+++ b/docs/pages/demo/datepicker/CustomDay.example.jsx
@@ -33,9 +33,9 @@ function WeekPicker(props) {
   const classes = useStyles(props);
   const [selectedDate, handleDateChange] = useState(new Date());
 
-  const renderWeekPickerDay = (date, selectedDate, DayComponentProps) => {
+  const renderWeekPickerDay = (date, selectedDates, DayComponentProps) => {
     let dateClone = makeJSDateObject(date);
-    let selectedDateClone = makeJSDateObject(selectedDate);
+    let selectedDateClone = makeJSDateObject(selectedDates[0]);
 
     const start = startOfWeek(selectedDateClone);
     const end = endOfWeek(selectedDateClone);


### PR DESCRIPTION
## Environment

| Tech                 | Version |
| -------------------- | ------- |
| @material-ui/pickers | v4.0.0-alpha.8        |

## Description

The DatePicker of 'Customization' section is broken.
https://next.material-ui-pickers.dev/demo/datepicker#customization