### PR TITLE
Add missing props for DateRangePickerToolbar

### DIFF
--- a/lib/src/DateRangePicker/DateRangePickerView.tsx
+++ b/lib/src/DateRangePicker/DateRangePickerView.tsx
@@ -45,30 +45,30 @@ interface DateRangePickerViewProps
 }
 
 export const DateRangePickerView: React.FC<DateRangePickerViewProps> = ({
-  open,
   calendars = 2,
+  className,
   currentlySelectingRangeEnd,
   date,
+  DateInputProps,
   disableAutoMonthSwitching = false,
   disableFuture,
   disableHighlightToday,
   disablePast,
+  endText,
+  isMobileKeyboardViewOpen,
   maxDate: unparsedMaxDate = defaultMaxDate,
   minDate: unparsedMinDate = defaultMinDate,
   onDateChange,
   onMonthChange,
+  open,
   reduceAnimations = defaultReduceAnimations,
   setCurrentlySelectingRangeEnd,
   shouldDisableDate,
-  toggleMobileKeyboardView,
-  isMobileKeyboardViewOpen,
   showToolbar,
   startText,
-  endText,
-  className,
-  DateInputProps,
-  toolbarTitle,
+  toggleMobileKeyboardView,
   toolbarFormat,
+  toolbarTitle,
   ...other
 }) => {
   const now = useNow();

--- a/lib/src/DateRangePicker/DateRangePickerView.tsx
+++ b/lib/src/DateRangePicker/DateRangePickerView.tsx
@@ -67,6 +67,8 @@ export const DateRangePickerView: React.FC<DateRangePickerViewProps> = ({
   endText,
   className,
   DateInputProps,
+  toolbarTitle,
+  toolbarFormat,
   ...other
 }) => {
   const now = useNow();
@@ -201,6 +203,8 @@ export const DateRangePickerView: React.FC<DateRangePickerViewProps> = ({
           setCurrentlySelectingRangeEnd={setCurrentlySelectingRangeEnd}
           startText={startText}
           endText={endText}
+          toolbarTitle={toolbarTitle}
+          toolbarFormat={toolbarFormat}
         />
       )}
 


### PR DESCRIPTION
This PR closes #1683 

## Description

Previously, `toolbarTitle` and `toolbarFormat` were not propagated all the way into `DateRangePickerToolbar`, making it impossible to change the default values.

This PR resolves this issue by verifying that all applicable props are passed to `DateRangePickerToolbar`