### PR TITLE
Add prop to render elements after calendar (#1795)

### DIFF
--- a/docs/pages/demo/daterangepicker/CustomCalendarRender.example.tsx
+++ b/docs/pages/demo/daterangepicker/CustomCalendarRender.example.tsx
@@ -1,12 +1,21 @@
 import * as React from 'react';
-import { DateRangePicker, DateRange, DateRangeDelimiter, PickersCalendar, PickersCalendarProps } from '@material-ui/pickers';
-import TextField from "@material-ui/core/TextField";
+import {
+  DateRangePicker,
+  DateRange,
+  DateRangeDelimiter,
+  PickersCalendar,
+  PickersCalendarProps,
+} from '@material-ui/pickers';
+import TextField from '@material-ui/core/TextField';
 
 interface CalendarWithValidationButtonProps extends PickersCalendarProps<Date> {
   validateCustomPeriod: () => void;
 }
 
-function CalendarWithValidationButton ({ validateCustomPeriod, ...pickersCalendarProps }: CalendarWithValidationButtonProps) {
+function CalendarWithValidationButton({
+  validateCustomPeriod,
+  ...pickersCalendarProps
+}: CalendarWithValidationButtonProps) {
   return (
     <React.Fragment>
       <PickersCalendar {...pickersCalendarProps} />

--- a/docs/pages/demo/daterangepicker/CustomCalendarRender.example.tsx
+++ b/docs/pages/demo/daterangepicker/CustomCalendarRender.example.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { DateRangePicker, DateRange, DateRangeDelimiter, PickersCalendar, PickersCalendarProps } from '@material-ui/pickers';
+import TextField from "@material-ui/core/TextField";
+
+interface CalendarWithValidationButtonProps extends PickersCalendarProps<Date> {
+  validateCustomPeriod: () => void;
+}
+
+function CalendarWithValidationButton ({ validateCustomPeriod, ...pickersCalendarProps }: CalendarWithValidationButtonProps) {
+  return (
+    <React.Fragment>
+      <PickersCalendar {...pickersCalendarProps} />
+
+      <button
+        type="button"
+        className="button date-dropdown__button--validate button--small button--alert"
+        onClick={validateCustomPeriod}
+      >
+        Validate
+      </button>
+    </React.Fragment>
+  );
+}
+
+export default function CustomCalendarRender() {
+  const [value, setValue] = React.useState<DateRange<Date>>([null, null]);
+
+  return (
+    <DateRangePicker
+      startText="Check-in"
+      endText="Check-out"
+      value={value}
+      onChange={(newValue) => setValue(newValue)}
+      slotComponents={{ Calendar: CalendarWithValidationButton }}
+      // @ts-ignore
+      slotProps={{ Calendar: { validateCustomPeriod: setValue } }}
+      renderInput={(startProps, endProps) => (
+        <React.Fragment>
+          <TextField {...startProps} />
+          <DateRangeDelimiter> to </DateRangeDelimiter>
+          <TextField {...endProps} />
+        </React.Fragment>
+      )}
+    />
+  );
+}

--- a/docs/pages/demo/daterangepicker/index.mdx
+++ b/docs/pages/demo/daterangepicker/index.mdx
@@ -10,7 +10,7 @@ import * as MinMaxDateRangePicker from './MinMaxDateRangePicker.example';
 import * as CalendarsDateRangePicker from './CalendarsDateRangePicker.example';
 import * as StaticDateRangePicker from './StaticDateRangePicker.example';
 import * as CustomRangeInputs from './CustomRangeInputs.example';
-import * as CustomCalendarRender from "./CustomCalendarRender.example";
+import * as CustomCalendarRender from './CustomCalendarRender.example';
 
 <PageMeta component="DateRangePicker" />
 

--- a/docs/pages/demo/daterangepicker/index.mdx
+++ b/docs/pages/demo/daterangepicker/index.mdx
@@ -10,6 +10,7 @@ import * as MinMaxDateRangePicker from './MinMaxDateRangePicker.example';
 import * as CalendarsDateRangePicker from './CalendarsDateRangePicker.example';
 import * as StaticDateRangePicker from './StaticDateRangePicker.example';
 import * as CustomRangeInputs from './CustomRangeInputs.example';
+import * as CustomCalendarRender from "./CustomCalendarRender.example";
 
 <PageMeta component="DateRangePicker" />
 
@@ -68,6 +69,12 @@ It is possible to render any picker without modal or popper. For that use `Stati
 <Hidden smDown>
   <Example paddingBottom source={StaticDateRangePicker} />
 </Hidden>
+
+#### Customize calendar rendering
+
+It is also possible to use a custom component as `Calendar` to customize its rendering.
+
+<Example source={CustomCalendarRender} />
 
 #### API
 

--- a/lib/src/DateRangePicker/DateRangePickerViewDesktop.tsx
+++ b/lib/src/DateRangePicker/DateRangePickerViewDesktop.tsx
@@ -17,7 +17,7 @@ import {
   isEndOfRange,
   DateValidationProps,
 } from '../_helpers/date-utils';
-import { DayProps as CalendarDayProps } from "../views/Calendar/Day";
+import { DayProps as CalendarDayProps } from '../views/Calendar/Day';
 
 export interface ExportedDesktopDateRangeCalendarProps<TDate> {
   /**

--- a/lib/src/DateRangePicker/DateRangePickerViewMobile.tsx
+++ b/lib/src/DateRangePicker/DateRangePickerViewMobile.tsx
@@ -12,7 +12,7 @@ import {
   isEndOfRange,
   DateValidationProps,
 } from '../_helpers/date-utils';
-import { DayProps as CalendarDayProps } from "../views/Calendar/Day";
+import { DayProps as CalendarDayProps } from '../views/Calendar/Day';
 
 export interface ExportedMobileDateRangeCalendarProps<TDate>
   extends Pick<ExportedDesktopDateRangeCalendarProps<TDate>, 'renderDay'> {
@@ -81,7 +81,7 @@ export function DateRangePickerViewMobile<TDate>(props: DesktopDateRangeCalendar
         isEndOfHighlighting: isEndOfRange(utils, day, date),
         ...DayProps,
       }),
-      ...slotProps.Calendar,
+    ...slotProps.Calendar,
   };
 
   return (


### PR DESCRIPTION
This allows us to render anything after the calendar (buttons, text…)
by passing the renderCalendarInfo props to DateRangePicker.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Right now this PR is missing tests and documentation for the new props.

Before doing that, I'd like some inputs from you to see whether my approach seems correct to you. I'd also like to update the `DatePicker` to provide similar functionnality if it is. I tried to follow the ideas discussed in the related issue #1795 

My interogation is: I am rendering the extra information at the right place (after the `Calendar` component) or should I render it inside the `Calendar` component.