### PR TITLE
[DatePicker] Add test for textbox aria-invalid

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,12 @@ workflows:
             - 'Build and analyze bundlesize'
 
       - jest_tests:
+          name: 'Dayjs jest tests'
+          lib: dayjs
+          requires:
+            - 'Build and analyze bundlesize'
+
+      - jest_tests:
           name: 'Moment jest tests'
           lib: moment
           requires:

--- a/lib/package.json
+++ b/lib/package.json
@@ -60,7 +60,7 @@
     "test": "jest",
     "test:typescript": "yarn rimraf src/__tests__/dist && tsc -p src/__tests__/tsconfig.json",
     "test:date-fns": "UTILS=date-fns yarn test",
-    "test:dayjs": "UTILS=datejs yarn test",
+    "test:dayjs": "UTILS=dayjs yarn test",
     "test:luxon": "UTILS=luxon yarn test",
     "test:moment": "UTILS=moment yarn test",
     "start": "rollup --config rollup.config.dev.js --watch & npx tsc --watch",

--- a/lib/src/__tests__/DatePickerTestingLib.test.tsx
+++ b/lib/src/__tests__/DatePickerTestingLib.test.tsx
@@ -4,7 +4,7 @@ import enLocale from 'date-fns/locale/en-US';
 import 'dayjs/locale/de';
 import TextField from '@material-ui/core/TextField';
 import { screen, waitFor } from '@testing-library/react';
-import { DateAdapter, getByMuiTest, utilsToUse, FakeTransitionComponent } from './test-utils';
+import { UtilClassToUse, getByMuiTest, utilsToUse, FakeTransitionComponent } from './test-utils';
 import { createClientRender, fireEvent } from './createClientRender';
 import {
   DatePicker,
@@ -130,10 +130,10 @@ describe('<DatePicker />', () => {
       const [value, setValue] = React.useState<unknown>(new Date('01/01/2020'));
 
       return (
-        <LocalizationProvider dateAdapter={DateAdapter} locale={locale}>
+        <LocalizationProvider dateAdapter={UtilClassToUse} locale={locale}>
           <Picker
             onChange={setValue}
-            renderInput={(props) => <TextField {...props} />}
+            renderInput={(props2) => <TextField {...props2} />}
             value={value}
             {...PickerProps}
           />

--- a/lib/src/__tests__/DatePickerTestingLib.test.tsx
+++ b/lib/src/__tests__/DatePickerTestingLib.test.tsx
@@ -1,9 +1,18 @@
 import * as React from 'react';
+import deLocale from 'date-fns/locale/de';
+import enLocale from 'date-fns/locale/en-US';
+import 'dayjs/locale/de';
 import TextField from '@material-ui/core/TextField';
 import { screen, waitFor } from '@testing-library/react';
-import { getByMuiTest, utilsToUse, FakeTransitionComponent } from './test-utils';
+import { DateAdapter, getByMuiTest, utilsToUse, FakeTransitionComponent } from './test-utils';
 import { createClientRender, fireEvent } from './createClientRender';
-import { DatePicker, MobileDatePicker, DesktopDatePicker } from '../index';
+import {
+  DatePicker,
+  DatePickerProps,
+  DesktopDatePicker,
+  LocalizationProvider,
+  MobileDatePicker,
+} from '../index';
 
 describe('<DatePicker />', () => {
   const render = createClientRender({ strict: false });
@@ -95,5 +104,78 @@ describe('<DatePicker />', () => {
 
     fireEvent.click(screen.getByLabelText('Jan 1, 2018'));
     expect(onChangeMock).not.toHaveBeenCalled();
+  });
+
+  describe('input validation', () => {
+    const locales = {
+      en: {
+        valid: 'January 2020',
+        invalid: 'Januar 2020',
+        dateFns: enLocale,
+      },
+      de: {
+        valid: 'Januar 2020',
+        invalid: 'Janua 2020',
+        dateFns: deLocale,
+      },
+    };
+
+    interface FormProps {
+      locale: any;
+      Picker: React.ElementType<DatePickerProps>;
+      PickerProps: Partial<DatePickerProps>;
+    }
+    const Form = (props: FormProps) => {
+      const { locale, Picker, PickerProps } = props;
+      const [value, setValue] = React.useState<unknown>(new Date('01/01/2020'));
+
+      return (
+        <LocalizationProvider dateAdapter={DateAdapter} locale={locale}>
+          <Picker
+            onChange={setValue}
+            renderInput={(props) => <TextField {...props} />}
+            value={value}
+            {...PickerProps}
+          />
+        </LocalizationProvider>
+      );
+    };
+
+    Object.keys(locales).forEach((locale2) => {
+      const { valid, invalid } = locales[locale2];
+      const locale = process.env.UTILS === 'date-fns' ? locales[locale2].dateFns : locale2;
+
+      it(`${locale2}: should set invalid`, () => {
+        render(
+          <Form
+            locale={locale}
+            Picker={DesktopDatePicker}
+            PickerProps={{ views: ['month', 'year'] }}
+          />
+        );
+        const input = screen.getByRole('textbox');
+        fireEvent.change(input, { target: { value: invalid } });
+        expect(input).toBeInvalid();
+      });
+
+      // Need to run with ICU loaded https://moment.github.io/luxon/docs/manual/install.html#node
+      if (process.env.UTILS === 'luxon') {
+        return;
+      }
+
+      it(`${locale2}: should set to valid when was invalid`, () => {
+        render(
+          <Form
+            locale={locale}
+            Picker={DesktopDatePicker}
+            PickerProps={{ views: ['month', 'year'] }}
+          />
+        );
+        const input = screen.getByRole('textbox');
+        fireEvent.change(input, { target: { value: invalid } });
+        fireEvent.change(input, { target: { value: valid } });
+        expect(input).toBeValid();
+      });
+    });
   });
 });

--- a/lib/src/__tests__/DatePickerTestingLib.test.tsx
+++ b/lib/src/__tests__/DatePickerTestingLib.test.tsx
@@ -107,19 +107,6 @@ describe('<DatePicker />', () => {
   });
 
   describe('input validation', () => {
-    const locales = {
-      en: {
-        valid: 'January 2020',
-        invalid: 'Januar 2020',
-        dateFns: enLocale,
-      },
-      de: {
-        valid: 'Januar 2020',
-        invalid: 'Janua 2020',
-        dateFns: deLocale,
-      },
-    };
-
     interface FormProps {
       locale: any;
       Picker: React.ElementType<DatePickerProps>;
@@ -141,11 +128,26 @@ describe('<DatePicker />', () => {
       );
     };
 
-    Object.keys(locales).forEach((locale2) => {
-      const { valid, invalid } = locales[locale2];
-      const locale = process.env.UTILS === 'date-fns' ? locales[locale2].dateFns : locale2;
+    const tests = [
+      {
+        locale: 'en',
+        valid: 'January 2020',
+        invalid: 'Januar 2020',
+        dateFns: enLocale,
+      },
+      {
+        locale: 'de',
+        valid: 'Januar 2020',
+        invalid: 'Janua 2020',
+        dateFns: deLocale,
+      },
+    ];
 
-      it(`${locale2}: should set invalid`, () => {
+    tests.forEach((test) => {
+      const { valid, invalid } = test;
+      const locale = process.env.UTILS === 'date-fns' ? test.dateFns : test.locale;
+
+      it(`${test.locale}: should set invalid`, () => {
         render(
           <Form
             locale={locale}
@@ -163,7 +165,7 @@ describe('<DatePicker />', () => {
         return;
       }
 
-      it(`${locale2}: should set to valid when was invalid`, () => {
+      it(`${test.locale}: should set to valid when was invalid`, () => {
         render(
           <Form
             locale={locale}

--- a/lib/src/__tests__/DateTimePickerTestingLib.test.tsx
+++ b/lib/src/__tests__/DateTimePickerTestingLib.test.tsx
@@ -8,6 +8,7 @@ import { DesktopDateTimePicker, StaticDateTimePicker } from '../DateTimePicker';
 describe('<DateTimePicker />', () => {
   // Doesn't work
   if (process.env.UTILS === 'dayjs') {
+    it('noop', () => {});
     return;
   }
 

--- a/lib/src/__tests__/DateTimePickerTestingLib.test.tsx
+++ b/lib/src/__tests__/DateTimePickerTestingLib.test.tsx
@@ -6,6 +6,11 @@ import { createClientRender } from './createClientRender';
 import { DesktopDateTimePicker, StaticDateTimePicker } from '../DateTimePicker';
 
 describe('<DateTimePicker />', () => {
+  // Doesn't work
+  if (process.env.UTILS === 'dayjs') {
+    return;
+  }
+
   const render = createClientRender({ strict: false });
 
   it('prop: mask – should take the mask prop into account', () => {

--- a/lib/src/__tests__/KeyboardDatePicker.test.tsx
+++ b/lib/src/__tests__/KeyboardDatePicker.test.tsx
@@ -5,6 +5,11 @@ import { mount } from './test-utils';
 import { DesktopDatePicker, DatePickerProps } from '../DatePicker/DatePicker';
 
 describe('e2e -- DatePicker keyboard input', () => {
+  // Doesn't work
+  if (process.env.UTILS === 'dayjs') {
+    return;
+  }
+
   const onChangeMock = jest.fn();
   let component: ReactWrapper<DatePickerProps>;
 

--- a/lib/src/__tests__/KeyboardDatePicker.test.tsx
+++ b/lib/src/__tests__/KeyboardDatePicker.test.tsx
@@ -7,6 +7,7 @@ import { DesktopDatePicker, DatePickerProps } from '../DatePicker/DatePicker';
 describe('e2e -- DatePicker keyboard input', () => {
   // Doesn't work
   if (process.env.UTILS === 'dayjs') {
+    it('noop', () => {});
     return;
   }
 

--- a/lib/src/__tests__/Validation.test.tsx
+++ b/lib/src/__tests__/Validation.test.tsx
@@ -14,6 +14,11 @@ const disableWeekends = (date: unknown) => {
 };
 
 describe('DatePicker validation', () => {
+  // Doesn't work
+  if (process.env.UTILS === 'dayjs') {
+    return;
+  }
+
   test.each`
     props                                     | input            | expectedError
     ${{}}                                     | ${'invalidText'} | ${'invalidDate'}

--- a/lib/src/__tests__/Validation.test.tsx
+++ b/lib/src/__tests__/Validation.test.tsx
@@ -13,154 +13,160 @@ const disableWeekends = (date: unknown) => {
   return isWeekend(utilsToUse.toJsDate(date));
 };
 
-describe('DatePicker validation', () => {
+describe('validation', () => {
   // Doesn't work
   if (process.env.UTILS === 'dayjs') {
+    it('noop', () => {});
     return;
   }
 
-  test.each`
-    props                                     | input            | expectedError
-    ${{}}                                     | ${'invalidText'} | ${'invalidDate'}
-    ${{ disablePast: true }}                  | ${'01/01/1900'}  | ${'disablePast'}
-    ${{ disableFuture: true }}                | ${'01/01/2050'}  | ${'disableFuture'}
-    ${{ minDate: new Date('01/01/2000') }}    | ${'01/01/1990'}  | ${'minDate'}
-    ${{ maxDate: new Date('01/01/2000') }}    | ${'01/01/2010'}  | ${'maxDate'}
-    ${{ shouldDisableDate: disableWeekends }} | ${'04/25/2020'}  | ${'shouldDisableDate'}
-  `('Should dispatch onError $expectedError', ({ props, input, expectedError }) => {
-    if (process.env.UTILS === 'luxon') {
-      return;
-    }
+  describe('DatePicker', () => {
+    test.each`
+      props                                     | input            | expectedError
+      ${{}}                                     | ${'invalidText'} | ${'invalidDate'}
+      ${{ disablePast: true }}                  | ${'01/01/1900'}  | ${'disablePast'}
+      ${{ disableFuture: true }}                | ${'01/01/2050'}  | ${'disableFuture'}
+      ${{ minDate: new Date('01/01/2000') }}    | ${'01/01/1990'}  | ${'minDate'}
+      ${{ maxDate: new Date('01/01/2000') }}    | ${'01/01/2010'}  | ${'maxDate'}
+      ${{ shouldDisableDate: disableWeekends }} | ${'04/25/2020'}  | ${'shouldDisableDate'}
+    `('Should dispatch onError $expectedError', ({ props, input, expectedError }) => {
+      if (process.env.UTILS === 'luxon') {
+        return;
+      }
 
-    const onErrorMock = jest.fn();
-    const component = mountPickerWithState(utilsToUse.date(), (stateProps) => (
-      <DesktopDatePicker {...stateProps} {...props} onError={onErrorMock} />
-    ));
+      const onErrorMock = jest.fn();
+      const component = mountPickerWithState(utilsToUse.date(), (stateProps) => (
+        <DesktopDatePicker {...stateProps} {...props} onError={onErrorMock} />
+      ));
 
-    component.find('input').simulate('change', {
-      target: {
-        value: input,
-      },
-    });
-
-    expect(onErrorMock).toBeCalledWith(expectedError, expect.anything());
-  });
-
-  it('It should properly annulate the error', () => {
-    if (process.env.UTILS === 'luxon') {
-      return;
-    }
-
-    const onErrorMock = jest.fn();
-    const component = mountPickerWithState(utilsToUse.date(), (stateProps) => (
-      <DesktopDatePicker {...stateProps} disablePast onError={onErrorMock} />
-    ));
-
-    component.find('input').simulate('change', {
-      target: {
-        value: '01/01/1900',
-      },
-    });
-
-    expect(onErrorMock).toHaveBeenCalledWith('disablePast', expect.anything());
-
-    component.find('input').simulate('change', {
-      target: {
-        value: '01/01/2099',
-      },
-    });
-
-    expect(onErrorMock).toHaveBeenCalledWith(null, expect.anything());
-  });
-});
-
-describe('TimePicker validation', () => {
-  const createTime = (time: string) => new Date(`01/01/2000 ${time}`);
-  const shouldDisableTime: TimePickerProps['shouldDisableTime'] = (value) => {
-    return value === 10;
-  };
-
-  test.each`
-    props                               | input            | expectedError
-    ${{}}                               | ${'invalidText'} | ${'invalidDate'}
-    ${{ minTime: createTime('08:00') }} | ${'03:00'}       | ${'minTime'}
-    ${{ maxTime: createTime('08:00') }} | ${'12:00'}       | ${'maxTime'}
-    ${{ shouldDisableTime }}            | ${'10:00'}       | ${'shouldDisableTime-hours'}
-    ${{ shouldDisableTime }}            | ${'00:10'}       | ${'shouldDisableTime-minutes'}
-  `('TimePicker should dispatch onError $expectedError', ({ props, input, expectedError }) => {
-    const onErrorMock = jest.fn();
-    const component = mountPickerWithState(utilsToUse.date(), (stateProps) => (
-      <DesktopTimePicker ampm={false} {...stateProps} {...props} onError={onErrorMock} />
-    ));
-
-    component.find('input').simulate('change', {
-      target: {
-        value: input,
-      },
-    });
-
-    expect(onErrorMock).toBeCalledWith(expectedError, expect.anything());
-  });
-});
-
-describe('DateRangePicker validation', () => {
-  test.each`
-    props                                     | startInput      | endInput        | expectedError
-    ${{}}                                     | ${'99/99/9999'} | ${'99/99/9999'} | ${['invalidDate', 'invalidDate']}
-    ${{}}                                     | ${'01/01/2020'} | ${'01/01/1920'} | ${['invalidRange', 'invalidRange']}
-    ${{ minDate: new Date('01/01/2000') }}    | ${'01/01/1990'} | ${'01/01/1990'} | ${['minDate', 'minDate']}
-    ${{ maxDate: new Date('01/01/2000') }}    | ${'01/01/2010'} | ${'01/01/2010'} | ${['maxDate', 'maxDate']}
-    ${{ disablePast: true }}                  | ${'01/01/1800'} | ${'01/01/2120'} | ${['disablePast', 'maxDate']}
-    ${{ disablePast: true }}                  | ${'01/01/1800'} | ${'01/01/2090'} | ${['disablePast', null]}
-    ${{ disableFuture: true }}                | ${'01/01/2010'} | ${'01/01/2050'} | ${[null, 'disableFuture']}
-    ${{ shouldDisableDate: disableWeekends }} | ${'04/25/2020'} | ${'06/25/2020'} | ${['shouldDisableDate', null]}
-  `('Should dispatch onError $expectedError', ({ props, startInput, endInput, expectedError }) => {
-    if (process.env.UTILS === 'luxon') {
-      return;
-    }
-
-    const onErrorMock = jest.fn();
-
-    const component = mountPickerWithState([null, null], (stateProps) => (
-      <DesktopDateRangePicker
-        {...stateProps}
-        {...props}
-        onError={onErrorMock}
-        renderInput={(startProps, endProps) => (
-          <React.Fragment>
-            <TextField {...startProps} />
-            <TextField {...endProps} />
-          </React.Fragment>
-        )}
-      />
-    ));
-
-    component
-      .find('input')
-      .at(0)
-      .simulate('change', {
+      component.find('input').simulate('change', {
         target: {
-          value: startInput,
+          value: input,
         },
       });
 
-    act(() => {
-      jest.runAllTimers();
+      expect(onErrorMock).toBeCalledWith(expectedError, expect.anything());
     });
 
-    component
-      .find('input')
-      .at(1)
-      .simulate('change', {
+    it('It should properly annulate the error', () => {
+      if (process.env.UTILS === 'luxon') {
+        return;
+      }
+
+      const onErrorMock = jest.fn();
+      const component = mountPickerWithState(utilsToUse.date(), (stateProps) => (
+        <DesktopDatePicker {...stateProps} disablePast onError={onErrorMock} />
+      ));
+
+      component.find('input').simulate('change', {
         target: {
-          value: endInput,
+          value: '01/01/1900',
         },
       });
 
-    act(() => {
-      jest.runAllTimers();
-    });
+      expect(onErrorMock).toHaveBeenCalledWith('disablePast', expect.anything());
 
-    expect(onErrorMock).toBeCalledWith(expectedError, expect.anything());
+      component.find('input').simulate('change', {
+        target: {
+          value: '01/01/2099',
+        },
+      });
+
+      expect(onErrorMock).toHaveBeenCalledWith(null, expect.anything());
+    });
+  });
+
+  describe('TimePicker', () => {
+    const createTime = (time: string) => new Date(`01/01/2000 ${time}`);
+    const shouldDisableTime: TimePickerProps['shouldDisableTime'] = (value) => {
+      return value === 10;
+    };
+
+    test.each`
+      props                               | input            | expectedError
+      ${{}}                               | ${'invalidText'} | ${'invalidDate'}
+      ${{ minTime: createTime('08:00') }} | ${'03:00'}       | ${'minTime'}
+      ${{ maxTime: createTime('08:00') }} | ${'12:00'}       | ${'maxTime'}
+      ${{ shouldDisableTime }}            | ${'10:00'}       | ${'shouldDisableTime-hours'}
+      ${{ shouldDisableTime }}            | ${'00:10'}       | ${'shouldDisableTime-minutes'}
+    `('TimePicker should dispatch onError $expectedError', ({ props, input, expectedError }) => {
+      const onErrorMock = jest.fn();
+      const component = mountPickerWithState(utilsToUse.date(), (stateProps) => (
+        <DesktopTimePicker ampm={false} {...stateProps} {...props} onError={onErrorMock} />
+      ));
+
+      component.find('input').simulate('change', {
+        target: {
+          value: input,
+        },
+      });
+
+      expect(onErrorMock).toBeCalledWith(expectedError, expect.anything());
+    });
+  });
+
+  describe('DateRangePicker', () => {
+    test.each`
+      props                                     | startInput      | endInput        | expectedError
+      ${{}}                                     | ${'99/99/9999'} | ${'99/99/9999'} | ${['invalidDate', 'invalidDate']}
+      ${{}}                                     | ${'01/01/2020'} | ${'01/01/1920'} | ${['invalidRange', 'invalidRange']}
+      ${{ minDate: new Date('01/01/2000') }}    | ${'01/01/1990'} | ${'01/01/1990'} | ${['minDate', 'minDate']}
+      ${{ maxDate: new Date('01/01/2000') }}    | ${'01/01/2010'} | ${'01/01/2010'} | ${['maxDate', 'maxDate']}
+      ${{ disablePast: true }}                  | ${'01/01/1800'} | ${'01/01/2120'} | ${['disablePast', 'maxDate']}
+      ${{ disablePast: true }}                  | ${'01/01/1800'} | ${'01/01/2090'} | ${['disablePast', null]}
+      ${{ disableFuture: true }}                | ${'01/01/2010'} | ${'01/01/2050'} | ${[null, 'disableFuture']}
+      ${{ shouldDisableDate: disableWeekends }} | ${'04/25/2020'} | ${'06/25/2020'} | ${['shouldDisableDate', null]}
+    `(
+      'Should dispatch onError $expectedError',
+      ({ props, startInput, endInput, expectedError }) => {
+        if (process.env.UTILS === 'luxon') {
+          return;
+        }
+
+        const onErrorMock = jest.fn();
+
+        const component = mountPickerWithState([null, null], (stateProps) => (
+          <DesktopDateRangePicker
+            {...stateProps}
+            {...props}
+            onError={onErrorMock}
+            renderInput={(startProps, endProps) => (
+              <React.Fragment>
+                <TextField {...startProps} />
+                <TextField {...endProps} />
+              </React.Fragment>
+            )}
+          />
+        ));
+
+        component
+          .find('input')
+          .at(0)
+          .simulate('change', {
+            target: {
+              value: startInput,
+            },
+          });
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        component
+          .find('input')
+          .at(1)
+          .simulate('change', {
+            target: {
+              value: endInput,
+            },
+          });
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(onErrorMock).toBeCalledWith(expectedError, expect.anything());
+      }
+    );
   });
 });


### PR DESCRIPTION
- Tests aria-invalid attribute on the DatePicker's input element when the locale is updated and the date becomes invalid through incorrect text input.

- Add test test for #1895 (https://github.com/dmtrKovalenko/date-io/pull/406)
