### PR TITLE
Add seconds to DateTimePicker view

### DIFF
--- a/docs/pages/demo/datetime-picker/CustomDateTimePicker.example.jsx
+++ b/docs/pages/demo/datetime-picker/CustomDateTimePicker.example.jsx
@@ -52,6 +52,17 @@ function CustomDateTimePicker(props) {
         onChange={handleClearedDateChange}
         renderInput={props => <TextField {...props} helperText="Clear Initial State" />}
       />
+
+      <DateTimePicker
+        value={selectedDate}
+        onChange={handleDateChange}
+        renderInput={props => <TextField {...props} helperText="With Seconds" />}
+        views={['year', 'month', 'date', 'hours', 'minutes', 'seconds']}
+        inputFormat={props.__willBeReplacedGetFormatString({
+          moment: 'YYYY/MM/DD HH:mm:ss A',
+          dateFns: 'yyyy/MM/dd HH:mm:ss a',
+        })}
+      />
     </React.Fragment>
   );
 }

--- a/docs/prop-types.json
+++ b/docs/prop-types.json
@@ -320,7 +320,7 @@
     },
     "onError": {
       "defaultValue": null,
-      "description": "Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).\nIn case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.\nThis can be used to render appropriate form error.\n\n[Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.\n@DateIOType",
+      "description": "Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).\nIn case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.\r\nThis can be used to render appropriate form error.\r\n\r\n[Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.\n@DateIOType",
       "name": "onError",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/hooks/useValidation.ts",
@@ -879,7 +879,7 @@
     },
     "renderInput": {
       "defaultValue": null,
-      "description": "The `renderInput` prop allows you to customize the rendered input.\nThe `props` argument of this render prop contains props of [TextField](https://material-ui.com/api/text-field/#textfield-api) that you need to forward.\nPay specific attention to the `ref` and `inputProps` keys.\n@example ```jsx\nrenderInput={props => <TextField {...props} />}\n````",
+      "description": "The `renderInput` prop allows you to customize the rendered input.\nThe `props` argument of this render prop contains props of [TextField](https://material-ui.com/api/text-field/#textfield-api) that you need to forward.\r\nPay specific attention to the `ref` and `inputProps` keys.\n@example ```jsx\rrenderInput={props => <TextField {...props} />}\r````",
       "name": "renderInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -1004,7 +1004,7 @@
     },
     "dateAdapter": {
       "defaultValue": null,
-      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\n```",
+      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\r\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\r\n```",
       "name": "dateAdapter",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/withDateAdapterProp.tsx",
@@ -1292,7 +1292,7 @@
     },
     "onError": {
       "defaultValue": null,
-      "description": "Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).\nIn case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.\nThis can be used to render appropriate form error.\n\n[Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.\n@DateIOType",
+      "description": "Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).\nIn case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.\r\nThis can be used to render appropriate form error.\r\n\r\n[Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.\n@DateIOType",
       "name": "onError",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/hooks/useValidation.ts",
@@ -1571,7 +1571,7 @@
     },
     "renderInput": {
       "defaultValue": null,
-      "description": "The `renderInput` prop allows you to customize the rendered input.\nThe `props` argument of this render prop contains props of [TextField](https://material-ui.com/api/text-field/#textfield-api) that you need to forward.\nPay specific attention to the `ref` and `inputProps` keys.\n@example ```jsx\nrenderInput={props => <TextField {...props} />}\n````",
+      "description": "The `renderInput` prop allows you to customize the rendered input.\nThe `props` argument of this render prop contains props of [TextField](https://material-ui.com/api/text-field/#textfield-api) that you need to forward.\r\nPay specific attention to the `ref` and `inputProps` keys.\n@example ```jsx\rrenderInput={props => <TextField {...props} />}\r````",
       "name": "renderInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -1696,7 +1696,7 @@
     },
     "dateAdapter": {
       "defaultValue": null,
-      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\n```",
+      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\r\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\r\n```",
       "name": "dateAdapter",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/withDateAdapterProp.tsx",
@@ -1956,7 +1956,7 @@
       },
       "required": false,
       "type": {
-        "name": "(\"year\" | \"date\" | \"month\" | \"hours\" | \"minutes\")[]"
+        "name": "DateTimePickerView[]"
       }
     },
     "openTo": {
@@ -1969,12 +1969,12 @@
       },
       "required": false,
       "type": {
-        "name": "\"year\" | \"date\" | \"month\" | \"hours\" | \"minutes\""
+        "name": "\"year\" | \"date\" | \"month\" | \"hours\" | \"minutes\" | \"seconds\""
       }
     },
     "onError": {
       "defaultValue": null,
-      "description": "Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).\nIn case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.\nThis can be used to render appropriate form error.\n\n[Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.\n@DateIOType",
+      "description": "Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).\nIn case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.\r\nThis can be used to render appropriate form error.\r\n\r\n[Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.\n@DateIOType",
       "name": "onError",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/hooks/useValidation.ts",
@@ -2619,7 +2619,7 @@
     },
     "renderInput": {
       "defaultValue": null,
-      "description": "The `renderInput` prop allows you to customize the rendered input.\nThe `props` argument of this render prop contains props of [TextField](https://material-ui.com/api/text-field/#textfield-api) that you need to forward.\nPay specific attention to the `ref` and `inputProps` keys.\n@example ```jsx\nrenderInput={props => <TextField {...props} />}\n````",
+      "description": "The `renderInput` prop allows you to customize the rendered input.\nThe `props` argument of this render prop contains props of [TextField](https://material-ui.com/api/text-field/#textfield-api) that you need to forward.\r\nPay specific attention to the `ref` and `inputProps` keys.\n@example ```jsx\rrenderInput={props => <TextField {...props} />}\r````",
       "name": "renderInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/PureDateInput.tsx",
@@ -2744,7 +2744,7 @@
     },
     "dateAdapter": {
       "defaultValue": null,
-      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\n```",
+      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\r\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\r\n```",
       "name": "dateAdapter",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/withDateAdapterProp.tsx",
@@ -3472,7 +3472,7 @@
     },
     "onError": {
       "defaultValue": null,
-      "description": "Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).\nIn case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.\nThis can be used to render appropriate form error.\n\n[Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.\n@DateIOType",
+      "description": "Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).\nIn case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.\r\nThis can be used to render appropriate form error.\r\n\r\n[Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.\n@DateIOType",
       "name": "onError",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/hooks/useValidation.ts",
@@ -3485,7 +3485,7 @@
     },
     "renderInput": {
       "defaultValue": null,
-      "description": "The `renderInput` prop allows you to customize the rendered input.\nThe `startProps` and `endProps` arguments of this render prop contains props of [TextField](https://material-ui.com/api/text-field/#textfield-api),\nthat you need to forward to the range start/end inputs respectively.\nPay specific attention to the `ref` and `inputProps` keys.\n@example ```jsx\n<DateRangePicker\nrenderInput={(startProps, endProps) => (\n  <React.Fragment>\n    <TextField {...startProps} />\n    <Typography> to <Typography>\n    <TextField {...endProps} />\n  </React.Fragment>;\n)}\n/>\n````",
+      "description": "The `renderInput` prop allows you to customize the rendered input.\nThe `startProps` and `endProps` arguments of this render prop contains props of [TextField](https://material-ui.com/api/text-field/#textfield-api),\r\nthat you need to forward to the range start/end inputs respectively.\r\nPay specific attention to the `ref` and `inputProps` keys.\n@example ```jsx\r<DateRangePicker\rrenderInput={(startProps, endProps) => (\r  <React.Fragment>\r    <TextField {...startProps} />\r    <Typography> to <Typography>\r    <TextField {...endProps} />\r  </React.Fragment>;\r)}\r/>\r````",
       "name": "renderInput",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/DateRangePicker/DateRangePickerInput.tsx",
@@ -3649,7 +3649,7 @@
     },
     "dateAdapter": {
       "defaultValue": null,
-      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\n```",
+      "description": "Allows to pass configured date-io adapter directly. More info [here](https://material-ui-pickers.dev/guides/date-adapter-passing)\n```jsx\r\ndateAdapter={new DateFnsAdapter({ locale: ruLocale })}\r\n```",
       "name": "dateAdapter",
       "parent": {
         "fileName": "material-ui-pickers/lib/src/_shared/withDateAdapterProp.tsx",

--- a/lib/src/DateTimePicker/DateTimePicker.tsx
+++ b/lib/src/DateTimePicker/DateTimePicker.tsx
@@ -15,7 +15,7 @@ import { ParsableDate, defaultMinDate, defaultMaxDate } from '../constants/prop-
 export type DateTimePickerView = 'year' | 'date' | 'month' | 'hours' | 'minutes' | 'seconds';
 
 export interface BaseDateTimePickerProps
-  extends WithViewsProps<'year' | 'date' | 'month' | 'hours' | 'minutes'>,
+  extends WithViewsProps<'year' | 'date' | 'month' | 'hours' | 'minutes' | 'seconds'>,
     ValidationProps<DateAndTimeValidationError, ParsableDate>,
     ExportedClockViewProps,
     ExportedCalendarViewProps {

--- a/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/lib/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -10,6 +10,8 @@ import { MaterialUiPickersDate } from '../typings/date';
 import { withDefaultProps } from '../_shared/withDefaultProps';
 import { ToolbarComponentProps } from '../Picker/SharedPickerProps';
 import { WrapperVariantContext } from '../wrappers/WrapperVariantContext';
+import { useMemo } from 'react';
+import { arrayIncludes } from '../_helpers/utils';
 
 const muiComponentConfig = { name: 'MuiPickersDateTimePickerToolbar' };
 
@@ -58,6 +60,7 @@ export const DateTimePickerToolbar: React.FC<ToolbarComponentProps> = withDefaul
     toolbarFormat,
     toolbarPlaceholder = '––',
     toolbarTitle = 'SELECT DATE & TIME',
+    views,
     ...other
   }) => {
     const utils = useUtils();
@@ -82,6 +85,9 @@ export const DateTimePickerToolbar: React.FC<ToolbarComponentProps> = withDefaul
 
       return utils.format(date, 'shortDate');
     }, [date, toolbarFormat, toolbarPlaceholder, utils]);
+
+    const hasSeconds = useMemo(() => arrayIncludes(views, 'seconds'), [views]);
+    const timeTypographyText = hasSeconds ? 'h4' : 'h3';
 
     return (
       <React.Fragment>
@@ -117,7 +123,7 @@ export const DateTimePickerToolbar: React.FC<ToolbarComponentProps> = withDefaul
             <div className={classes.timeContainer}>
               <ToolbarButton
                 tabIndex={-1}
-                variant="h3"
+                variant={timeTypographyText}
                 data-mui-test="hours"
                 onClick={() => setOpenView('hours')}
                 selected={openView === 'hours'}
@@ -125,17 +131,37 @@ export const DateTimePickerToolbar: React.FC<ToolbarComponentProps> = withDefaul
                 typographyClassName={classes.timeTypography}
               />
 
-              <ToolbarText variant="h3" value=":" className={classes.separator} />
+              <ToolbarText variant={timeTypographyText} value=":" className={classes.separator} />
 
               <ToolbarButton
                 tabIndex={-1}
-                variant="h3"
+                variant={timeTypographyText}
                 data-mui-test="minutes"
                 onClick={() => setOpenView('minutes')}
                 selected={openView === 'minutes'}
                 value={date ? utils.format(date, 'minutes') : '--'}
                 typographyClassName={classes.timeTypography}
               />
+
+              {hasSeconds && (
+                <>
+                  <ToolbarText
+                    variant={timeTypographyText}
+                    value=":"
+                    className={classes.separator}
+                  />
+
+                  <ToolbarButton
+                    tabIndex={-1}
+                    variant={timeTypographyText}
+                    data-mui-test="seconds"
+                    onClick={() => setOpenView('seconds')}
+                    selected={openView === 'seconds'}
+                    value={date ? utils.format(date, 'seconds') : '--'}
+                    typographyClassName={classes.timeTypography}
+                  />
+                </>
+              )}
             </div>
           </PickerToolbar>
         )}

--- a/lib/src/__tests__/DateTimePickerTestingLib.test.tsx
+++ b/lib/src/__tests__/DateTimePickerTestingLib.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { utilsToUse } from './test-utils';
+import { getByMuiTest, utilsToUse } from './test-utils';
 import TextField from '@material-ui/core/TextField';
-import { DesktopDateTimePicker } from '../DateTimePicker';
+import { DesktopDateTimePicker, MobileDateTimePicker } from '../DateTimePicker';
 import { createClientRender } from './createClientRender';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, getByText, screen, waitFor } from '@testing-library/react';
 
 describe('<DateTimePicker />', () => {
   const render = createClientRender({ strict: false });
@@ -62,5 +62,42 @@ describe('<DateTimePicker />', () => {
 
     await waitFor(() => screen.getByRole('dialog'));
     expect(screen.getByLabelText('11 hours').getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('prop: views – seconds is visible', async () => {
+    render(
+      <MobileDateTimePicker
+        open
+        onChange={() => {}}
+        ampm={false}
+        renderInput={props => <TextField {...props} />}
+        value={utilsToUse.date('2018-01-02T03:04:05.000Z')}
+        views={['year', 'month', 'date', 'hours', 'minutes', 'seconds']}
+      />
+    );
+
+    await waitFor(() => screen.getByRole('dialog'));
+    expect(getByMuiTest('seconds').firstChild?.textContent).toBe('05');
+  });
+
+  it('views: clicking on seconds opens seconds view', async () => {
+    render(
+      <MobileDateTimePicker
+        open
+        onChange={() => {}}
+        ampm={false}
+        renderInput={props => <TextField {...props} />}
+        value={utilsToUse.date('2018-01-02T03:04:05.000Z')}
+        views={['year', 'month', 'date', 'hours', 'minutes', 'seconds']}
+      />
+    );
+
+    await waitFor(() => screen.getByRole('dialog'));
+
+    fireEvent.click(getByMuiTest('seconds'));
+
+    expect(getByText(getByMuiTest('seconds'), '05')).toHaveClass(
+      'MuiPickersToolbarText-toolbarBtnSelected'
+    );
   });
 });

--- a/lib/src/__tests__/test-utils.tsx
+++ b/lib/src/__tests__/test-utils.tsx
@@ -20,7 +20,7 @@ export function getAllByMuiTest(
   id: Matcher,
   container: HTMLElement = document.body,
   options?: MatcherOptions
-): Element[] {
+): HTMLElement[] {
   const els = queryAllByMuiTest(container, id, options);
   if (!els.length) {
     throw queryHelpers.getElementError(
@@ -31,7 +31,7 @@ export function getAllByMuiTest(
   return els;
 }
 
-export function getByMuiTest(...args: Parameters<typeof getAllByMuiTest>): Element {
+export function getByMuiTest(...args: Parameters<typeof getAllByMuiTest>): HTMLElement {
   const result = getAllByMuiTest(...args);
   if (result.length > 0) {
     return result[0];


### PR DESCRIPTION
- Add seconds as an available view in DateTimePickerView
- Use DateTimePickerView type as the type for views and openTo
- Change typography variant depending on whether seconds are being displayed or not
- set number of grid elements depending on seconds view

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
