### PR TITLE
[core] Use the same start command as main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ We are using yarn for development and linking, so you need to make
 
 ```sh
 yarn
-yarn dev
+yarn docs:dev
 ```
 
 to start the development environment and to be sure the `lib` folder is linked properly to the `docs` and your changes will be applied to the docs website.

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "start": "yarn dev",
-    "dev": "yarn workspace docs dev",
+    "start": "yarn docs:dev",
+    "docs:dev": "yarn workspace docs dev",
     "e2e:run": "cypress run",
     "e2e:open": "cypress open",
     "docgen": "node docs/scripts/docgen.js",


### PR DESCRIPTION
Reduce the friction of switching contributions between main and picker repositories.

https://github.com/mui-org/material-ui/blob/70f3ce3ce543a156103fd53979017ffaf9aa5429/package.json#L15