### PR TITLE
Fix not rerendering days when inCurrentMonth changes

### DIFF
--- a/lib/src/views/Calendar/Day.tsx
+++ b/lib/src/views/Calendar/Day.tsx
@@ -251,6 +251,7 @@ export const areDayPropsEqual = (prevProps: DayProps, nextProps: DayProps) => {
     prevProps.showDaysOutsideCurrentMonth === nextProps.showDaysOutsideCurrentMonth &&
     prevProps.disableHighlightToday === nextProps.disableHighlightToday &&
     prevProps.className === nextProps.className &&
+    prevProps.inCurrentMonth === nextProps.inCurrentMonth &&
     prevProps.onDayFocus === nextProps.onDayFocus &&
     prevProps.onDaySelect === nextProps.onDaySelect
   );

--- a/lib/src/views/Calendar/SlideTransition.tsx
+++ b/lib/src/views/Calendar/SlideTransition.tsx
@@ -77,7 +77,7 @@ export const SlideTransition: React.SFC<SlideTransitionProps> = ({
 }) => {
   const classes = useStyles();
   if (reduceAnimations) {
-    return <div className={className}>{children}</div>;
+    return <div className={clsx(classes.root, className)}>{children}</div>;
   }
 
   const transitionClasses = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #1993 and also closes #1756 

The root of this issue was missing check for `inCurrentMonth` in `React.memo`. The same day with the same `key` was rendered in the new month, so react basically didn't change it only moved the node from one place to another one. 

Didn't reproduce without `reduceAnimation` because transition group is mounting and unmounting the whole component on animation. 
