### PR TITLE
autoOk was removed

### DIFF
--- a/docs/pages/guides/StaticComponents.example.jsx
+++ b/docs/pages/guides/StaticComponents.example.jsx
@@ -6,7 +6,7 @@ import { useStaticState, ClockView, Calendar } from '@material-ui/pickers';
 function StaticPickers() {
   const [value, handleDateChange] = useState(new Date());
 
-  // you can past mostly all available props, like minDate, maxDate, autoOk and so on
+  // You can past mostly all available props, like minDate, maxDate, and so on
   const { pickerProps, wrapperProps } = useStaticState({
     value,
     onChange: handleDateChange,


### PR DESCRIPTION
Not sure when autoOk was removed, but I've just updated to the latest alpha10 from alpha7, and TypeScript flagged the property as an error.

If it wasn't removed, please disregard the PR. I no longer see `autoOk` at https://dev.material-ui-pickers.dev/api/DateTimePicker though.