### PR TITLE
[docs] Fix `inputRef` date picker customization demo

### DIFF
--- a/docs/pages/demo/daterangepicker/CustomRangeInputs.example.tsx
+++ b/docs/pages/demo/daterangepicker/CustomRangeInputs.example.tsx
@@ -11,7 +11,10 @@ function CustomRangeInputs() {
       onChange={(date) => handleDateChange(date)}
       renderInput={(startProps, endProps) => (
         <React.Fragment>
-          <input ref={startProps.inputRef as React.Ref<HTMLInputElement>} {...startProps.inputProps} />
+          <input
+            ref={startProps.inputRef as React.Ref<HTMLInputElement>}
+            {...startProps.inputProps}
+          />
           <input ref={endProps.inputRef as React.Ref<HTMLInputElement>} {...endProps.inputProps} />
         </React.Fragment>
       )}

--- a/docs/pages/demo/daterangepicker/CustomRangeInputs.example.tsx
+++ b/docs/pages/demo/daterangepicker/CustomRangeInputs.example.tsx
@@ -11,8 +11,8 @@ function CustomRangeInputs() {
       onChange={(date) => handleDateChange(date)}
       renderInput={(startProps, endProps) => (
         <React.Fragment>
-          <input ref={startProps.ref as React.Ref<HTMLInputElement>} {...startProps.inputProps} />
-          <input ref={endProps.ref as React.Ref<HTMLInputElement>} {...endProps.inputProps} />
+          <input ref={startProps.inputRef as React.Ref<HTMLInputElement>} {...startProps.inputProps} />
+          <input ref={endProps.inputRef as React.Ref<HTMLInputElement>} {...endProps.inputProps} />
         </React.Fragment>
       )}
     />


### PR DESCRIPTION
Fixes Issue #2027.

Applying the `inputRef` instead of `ref` to the `<input />` component in the demo fixes the issue of the picker closing prematurely after a single date pick instead of waiting for both dates of the range to be picked.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
