### PR TITLE
[core] Lift peer dependencies of date libs

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -35,6 +35,10 @@
     "@material-ui/core": "^4.10.1",
     "@material-ui/lab": "^4.0.0-alpha.54",
     "@types/react": "^16.8.6",
+    "date-fns": "^2.0.0",
+    "dayjs": "^1.8.17",
+    "luxon": "^1.21.3",
+    "moment": "^2.24.0",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },
@@ -43,6 +47,18 @@
       "optional": true
     },
     "@material-ui/lab": {
+      "optional": true
+    },
+    "date-fns": {
+      "optional": true
+    },
+    "dayjs": {
+      "optional": true
+    },
+    "luxon": {
+      "optional": true
+    },
+    "moment": {
       "optional": true
     }
   },


### PR DESCRIPTION
Lifts peer dependencies on date utils as optional. Otherwise you currently get a lot of missing peer dependency warnings when install v4:

```bash
warning "workspace-aggregator-65b683a5-1b32-4e5f-bd47-27b2d2dc6468 > docs > @material-ui/pickers > @date-io/dayjs@2.8.0" has unmet peer dependency "dayjs@^1.8.17".
warning "workspace-aggregator-65b683a5-1b32-4e5f-bd47-27b2d2dc6468 > docs > @material-ui/pickers > @date-io/luxon@2.8.0" has unmet peer dependency "luxon@^1.21.3".
warning "workspace-aggregator-65b683a5-1b32-4e5f-bd47-27b2d2dc6468 > docs > @material-ui/pickers > @date-io/moment@2.8.0" has unmet peer dependency "moment@^2.24.0".
```

Peer dependencies lifted:

- `@date-io/date-fns`: https://github.com/dmtrKovalenko/date-io/blob/v2.8.0/packages/date-fns/package.json#L32-L34
- `@date-io/dayjs`: https://github.com/dmtrKovalenko/date-io/blob/v2.8.0/packages/dayjs/package.json#L8-L10
- `@date-io/luxon`: https://github.com/dmtrKovalenko/date-io/blob/v2.8.0/packages/luxon/package.json#L11-L13
- `@date-io/moment`: https://github.com/dmtrKovalenko/date-io/blob/v2.8.0/packages/moment/package.json#L8-L10

Ideally we'd warn if none is fulfilled but in the end we don't know which adapter is used at install time. However, having too many warnings numbs users to ignore these which is worse


