### PR TITLE
Allow React 17 in the peer dependencies

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -35,8 +35,8 @@
     "@date-io/core": "^1.3.6",
     "@material-ui/core": "^4.0.0",
     "prop-types": "^15.6.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4"
+    "react": "^16.8.4 || ^17",
+    "react-dom": "^16.8.4 || ^17"
   },
   "dependencies": {
     "@babel/runtime": "^7.6.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -35,8 +35,8 @@
     "@date-io/core": "^1.3.6",
     "@material-ui/core": "^4.0.0",
     "prop-types": "^15.6.0",
-    "react": "^16.8.4 || ^17",
-    "react-dom": "^16.8.4 || ^17"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.6.0",


### PR DESCRIPTION
Npm 7 doesn't like installing without using --legacy-peer-deps, so it would be nice to ot have to do that

- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Fixes #2179